### PR TITLE
Add `no_std` support

### DIFF
--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -1,0 +1,25 @@
+name: Rust+no_std
+
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ '**' ]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: '-D warnings'
+
+jobs:
+  build-nostd:
+    name: Build on no_std target (thumbv7em-none-eabi)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: thumbv7em-none-eabi
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features
+      - run: cargo build --target thumbv7em-none-eabi --release
+      - run: cargo build --target thumbv7em-none-eabi --release --features serde

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,5 @@ indexmap = "1.9.3"
 litemap = "0.7.0"
 
 [features]
-default = ["std"]
+default = []
 std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,7 @@ linked-hash-map = "0.5.6"
 linear-map = "1.2.0"
 indexmap = "1.9.3"
 litemap = "0.7.0"
+
+[features]
+default = ["std"]
+std = []

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -30,15 +30,21 @@ impl<K: Clone + PartialEq, V: Clone, const N: usize> Clone for Map<K, V, N> {
     }
 }
 
-#[test]
-fn map_can_be_cloned() {
-    let mut m: Map<u8, u8, 16> = Map::new();
-    m.insert(0, 42);
-    assert_eq!(42, *m.clone().get(&0).unwrap());
-}
+#[cfg(test)]
+mod test {
 
-#[test]
-fn empty_map_can_be_cloned() {
-    let m: Map<u8, u8, 0> = Map::new();
-    assert!(m.clone().is_empty());
+    use super::*;
+
+    #[test]
+    fn map_can_be_cloned() {
+        let mut m: Map<u8, u8, 16> = Map::new();
+        m.insert(0, 42);
+        assert_eq!(42, *m.clone().get(&0).unwrap());
+    }
+
+    #[test]
+    fn empty_map_can_be_cloned() {
+        let m: Map<u8, u8, 0> = Map::new();
+        assert!(m.clone().is_empty());
+    }
 }

--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -19,7 +19,7 @@
 // SOFTWARE.
 
 use crate::Map;
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 impl<K: PartialEq, V, const N: usize> Default for Map<K, V, N> {
     /// Make a default empty [`Map`].
@@ -58,39 +58,45 @@ impl<K: PartialEq, V, const N: usize> Drop for Map<K, V, N> {
     }
 }
 
-#[test]
-fn makes_default_map() {
-    let m: Map<u8, u8, 8> = Map::default();
-    assert_eq!(0, m.len());
-}
+#[cfg(test)]
+mod test {
 
-#[test]
-fn makes_new_map() {
-    let m: Map<u8, u8, 8> = Map::new();
-    assert_eq!(0, m.len());
-}
+    use super::*;
 
-#[test]
-fn drops_correctly() {
-    let _m: Map<Vec<u8>, u8, 8> = Map::new();
-}
+    #[test]
+    fn makes_default_map() {
+        let m: Map<u8, u8, 8> = Map::default();
+        assert_eq!(0, m.len());
+    }
 
-#[test]
-fn drops_keys() {
-    use std::rc::Rc;
-    let mut m: Map<Rc<()>, (), 8> = Map::new();
-    let k = Rc::new(());
-    m.insert(Rc::clone(&k), ());
-    drop(m);
-    assert_eq!(Rc::strong_count(&k), 1);
-}
+    #[test]
+    fn makes_new_map() {
+        let m: Map<u8, u8, 8> = Map::new();
+        assert_eq!(0, m.len());
+    }
 
-#[test]
-fn drops_values() {
-    use std::rc::Rc;
-    let mut m: Map<(), Rc<()>, 8> = Map::new();
-    let v = Rc::new(());
-    m.insert((), Rc::clone(&v));
-    drop(m);
-    assert_eq!(Rc::strong_count(&v), 1);
+    #[test]
+    fn drops_correctly() {
+        let _m: Map<Vec<u8>, u8, 8> = Map::new();
+    }
+
+    #[test]
+    fn drops_keys() {
+        use std::rc::Rc;
+        let mut m: Map<Rc<()>, (), 8> = Map::new();
+        let k = Rc::new(());
+        m.insert(Rc::clone(&k), ());
+        drop(m);
+        assert_eq!(Rc::strong_count(&k), 1);
+    }
+
+    #[test]
+    fn drops_values() {
+        use std::rc::Rc;
+        let mut m: Map<(), Rc<()>, 8> = Map::new();
+        let v = Rc::new(());
+        m.insert((), Rc::clone(&v));
+        drop(m);
+        assert_eq!(Rc::strong_count(&v), 1);
+    }
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -19,8 +19,8 @@
 // SOFTWARE.
 
 use crate::Map;
-use std::fmt;
-use std::fmt::{Debug, Display, Formatter};
+use core::fmt;
+use core::fmt::{Debug, Display, Formatter};
 
 impl<K: PartialEq + Display, V: Display, const N: usize> Display for Map<K, V, N> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -32,24 +32,30 @@ impl<K: PartialEq + Display, V: Display, const N: usize> Debug for Map<K, V, N> 
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let mut parts = vec![];
         for (k, v) in self.iter() {
-            parts.push(format!("{k}: {v}"));
+            parts.push(std::format!("{k}: {v}"));
         }
-        f.write_str(format!("{{{}}}", parts.join(", ").as_str()).as_str())
+        f.write_str(std::format!("{{{}}}", parts.join(", ").as_str()).as_str())
     }
 }
 
-#[test]
-fn debugs_map() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    m.insert("one", 42);
-    m.insert("two", 16);
-    assert_eq!("{one: 42, two: 16}", format!("{:?}", m));
-}
+#[cfg(test)]
+mod test {
 
-#[test]
-fn displays_map() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    m.insert("one", 42);
-    m.insert("two", 16);
-    assert_eq!("{one: 42, two: 16}", format!("{}", m));
+    use super::*;
+
+    #[test]
+    fn debugs_map() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        m.insert("one", 42);
+        m.insert("two", 16);
+        assert_eq!("{one: 42, two: 16}", format!("{:?}", m));
+    }
+
+    #[test]
+    fn displays_map() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        m.insert("one", 42);
+        m.insert("two", 16);
+        assert_eq!("{one: 42, two: 16}", format!("{}", m));
+    }
 }

--- a/src/eq.rs
+++ b/src/eq.rs
@@ -30,12 +30,14 @@ impl<K: PartialEq, V: PartialEq, const N: usize> PartialEq for Map<K, V, N> {
     /// let mut m2: micromap::Map<u8, i32, 10> = micromap::Map::new();
     /// m1.insert(1, 42);
     /// m2.insert(1, 42);
+    /// #[cfg(std)]
     /// assert_eq!(m1, m2);
     /// // two maps with different order of key-value pairs are still equal:
     /// m1.insert(2, 1);
     /// m1.insert(3, 16);
     /// m2.insert(3, 16);
     /// m2.insert(2, 1);
+    /// #[cfg(std)]
     /// assert_eq!(m1, m2);
     /// ```
     #[inline]

--- a/src/eq.rs
+++ b/src/eq.rs
@@ -46,11 +46,17 @@ impl<K: PartialEq, V: PartialEq, const N: usize> PartialEq for Map<K, V, N> {
 
 impl<K: Eq, V: Eq, const N: usize> Eq for Map<K, V, N> {}
 
-#[test]
-fn compares_two_maps() {
-    let mut m1: Map<&str, i32, 10> = Map::new();
-    m1.insert("first", 42);
-    let mut m2: Map<&str, i32, 10> = Map::new();
-    m2.insert("first", 42);
-    assert!(m1.eq(&m2));
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn compares_two_maps() {
+        let mut m1: Map<&str, i32, 10> = Map::new();
+        m1.insert("first", 42);
+        let mut m2: Map<&str, i32, 10> = Map::new();
+        m2.insert("first", 42);
+        assert!(m1.eq(&m2));
+    }
 }

--- a/src/from.rs
+++ b/src/from.rs
@@ -41,39 +41,45 @@ impl<K: PartialEq, V, const N: usize> From<[(K, V); N]> for Map<K, V, N> {
 }
 
 #[cfg(test)]
-const TEST_ARRAY: [(i32, &str); 5] = [(1, "sun"), (2, "mon"), (3, "tue"), (4, "wed"), (5, "thu")];
+mod test {
 
-#[test]
-fn from_iter() {
-    let vec = Vec::from(TEST_ARRAY);
-    let m: Map<i32, &str, 10> = Map::from_iter(vec);
-    assert_eq!(m.len(), 5);
-}
+    use super::*;
 
-#[test]
-#[should_panic]
-#[cfg(debug_assertions)]
-fn from_larger_iter() {
-    let vec = Vec::from(TEST_ARRAY);
-    let _m: Map<i32, &str, 1> = Map::from_iter(vec);
-}
+    const TEST_ARRAY: [(i32, &str); 5] =
+        [(1, "sun"), (2, "mon"), (3, "tue"), (4, "wed"), (5, "thu")];
 
-#[test]
-fn from_array() {
-    let m = Map::from(TEST_ARRAY);
-    assert_eq!(m.len(), 5);
-}
+    #[test]
+    fn from_iter() {
+        let vec = Vec::from(TEST_ARRAY);
+        let m: Map<i32, &str, 10> = Map::from_iter(vec);
+        assert_eq!(m.len(), 5);
+    }
 
-#[test]
-fn array_into_map() {
-    let m: Map<i32, &str, 5> = TEST_ARRAY.into();
-    assert_eq!(m.len(), 5);
-}
+    #[test]
+    #[should_panic]
+    #[cfg(debug_assertions)]
+    fn from_larger_iter() {
+        let vec = Vec::from(TEST_ARRAY);
+        let _m: Map<i32, &str, 1> = Map::from_iter(vec);
+    }
 
-#[test]
-fn from_with_duplicates() {
-    let arr = [(1, "sun"), (2, "mon"), (3, "tue"), (1, "wed"), (2, "thu")];
-    let m = Map::from(arr);
-    assert_eq!(m.len(), 3);
-    assert_eq!(m[&2], "thu");
+    #[test]
+    fn from_array() {
+        let m = Map::from(TEST_ARRAY);
+        assert_eq!(m.len(), 5);
+    }
+
+    #[test]
+    fn array_into_map() {
+        let m: Map<i32, &str, 5> = TEST_ARRAY.into();
+        assert_eq!(m.len(), 5);
+    }
+
+    #[test]
+    fn from_with_duplicates() {
+        let arr = [(1, "sun"), (2, "mon"), (3, "tue"), (1, "wed"), (2, "thu")];
+        let m = Map::from(arr);
+        assert_eq!(m.len(), 3);
+        assert_eq!(m[&2], "thu");
+    }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -19,8 +19,8 @@
 // SOFTWARE.
 
 use crate::Map;
-use std::borrow::Borrow;
-use std::ops::{Index, IndexMut};
+use core::borrow::Borrow;
+use core::ops::{Index, IndexMut};
 
 impl<K: Eq + Borrow<Q>, Q: Eq + ?Sized, V, const N: usize> Index<&Q> for Map<K, V, N> {
     type Output = V;
@@ -40,45 +40,51 @@ impl<K: Eq + Borrow<Q>, Q: Eq + ?Sized, V, const N: usize> IndexMut<&Q> for Map<
     }
 }
 
-#[test]
-fn index() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    m.insert("first", 42);
-    assert_eq!(m["first"], 42);
-}
-
-#[test]
-fn index_mut() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    m.insert("first", 42);
-    m["first"] += 10;
-    assert_eq!(m["first"], 52);
-}
-
-#[test]
-#[should_panic]
-fn wrong_index() -> () {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    m.insert("first", 42);
-    assert_eq!(m["second"], 42);
-}
-
 #[cfg(test)]
-#[derive(PartialEq, Eq)]
-struct Container {
-    pub t: i32,
-}
+mod test {
 
-#[cfg(test)]
-impl Borrow<i32> for Container {
-    fn borrow(&self) -> &i32 {
-        &self.t
+    use super::*;
+
+    #[test]
+    fn index() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        m.insert("first", 42);
+        assert_eq!(m["first"], 42);
     }
-}
 
-#[test]
-fn index_by_borrow() {
-    let mut m: Map<Container, i32, 10> = Map::new();
-    m.insert(Container { t: 10 }, 42);
-    assert_eq!(m[&10], 42);
+    #[test]
+    fn index_mut() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        m.insert("first", 42);
+        m["first"] += 10;
+        assert_eq!(m["first"], 52);
+    }
+
+    #[test]
+    #[should_panic]
+    fn wrong_index() -> () {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        m.insert("first", 42);
+        assert_eq!(m["second"], 42);
+    }
+
+    #[cfg(test)]
+    #[derive(PartialEq, Eq)]
+    struct Container {
+        pub t: i32,
+    }
+
+    #[cfg(test)]
+    impl Borrow<i32> for Container {
+        fn borrow(&self) -> &i32 {
+            &self.t
+        }
+    }
+
+    #[test]
+    fn index_by_borrow() {
+        let mut m: Map<Container, i32, 10> = Map::new();
+        m.insert(Container { t: 10 }, 42);
+        assert_eq!(m[&10], 42);
+    }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -54,18 +54,24 @@ impl<K: PartialEq, V, const N: usize> Iterator for IntoKeys<K, V, N> {
     }
 }
 
-#[test]
-fn iterate_keys() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    m.insert("foo", 0);
-    m.insert("bar", 0);
-    assert_eq!(m.keys().collect::<Vec<_>>(), [&"foo", &"bar"]);
-}
+#[cfg(test)]
+mod test {
 
-#[test]
-fn iterate_into_keys() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    m.insert("foo", 0);
-    m.insert("bar", 0);
-    assert_eq!(m.into_keys().collect::<Vec<_>>(), ["foo", "bar"]);
+    use super::*;
+
+    #[test]
+    fn iterate_keys() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        m.insert("foo", 0);
+        m.insert("bar", 0);
+        assert_eq!(m.keys().collect::<Vec<_>>(), [&"foo", &"bar"]);
+    }
+
+    #[test]
+    fn iterate_into_keys() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        m.insert("foo", 0);
+        m.insert("bar", 0);
+        assert_eq!(m.into_keys().collect::<Vec<_>>(), ["foo", "bar"]);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //! will have exactly ten elements. An attempt to add an 11th element will lead
 //! to a panic.
 
-#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+#![cfg_attr(all(not(feature = "std"), not(doc), not(test)), no_std)]
 #![doc(html_root_url = "https://docs.rs/micromap/0.0.0")]
 #![deny(warnings)]
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@
 //! let mut m : Map<u64, &str, 10> = Map::new();
 //! m.insert(1, "Hello, world!");
 //! m.insert(2, "Good bye!");
+//! #[cfg(std)]
 //! assert_eq!(2, m.len());
 //! ```
 //!
@@ -75,6 +76,7 @@ use core::mem::MaybeUninit;
 /// let mut m : micromap::Map<u64, &str, 8> = micromap::Map::new();
 /// m.insert(1, "Jeff Lebowski");
 /// m.insert(2, "Walter Sobchak");
+/// #[cfg(std)]
 /// assert_eq!(2, m.len());
 /// ```
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,14 +42,18 @@
 //! will have exactly ten elements. An attempt to add an 11th element will lead
 //! to a panic.
 
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 #![doc(html_root_url = "https://docs.rs/micromap/0.0.0")]
 #![deny(warnings)]
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
 #![allow(clippy::multiple_inherent_impl)]
 #![allow(clippy::multiple_crate_versions)]
+
+#[cfg(feature = "std")]
+mod debug;
+
 mod clone;
 mod ctors;
-mod debug;
 mod eq;
 mod from;
 mod index;
@@ -60,7 +64,7 @@ mod map;
 mod serialization;
 mod values;
 
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 /// A faster alternative of [`std::collections::HashMap`].
 ///

--- a/src/map.rs
+++ b/src/map.rs
@@ -19,9 +19,9 @@
 // SOFTWARE.
 
 use crate::Map;
-use std::borrow::Borrow;
-use std::mem;
-use std::mem::MaybeUninit;
+use core::borrow::Borrow;
+use core::mem;
+use core::mem::MaybeUninit;
 
 impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     /// Get its total capacity.
@@ -92,6 +92,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
         let mut i = 0;
         loop {
             if i == self.next {
+                #[cfg(feature = "std")]
                 debug_assert!(target < N, "No more keys available in the map");
                 break;
             }
@@ -217,229 +218,235 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     }
 }
 
-#[test]
-fn insert_and_check_length() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    m.insert("first", 42);
-    assert_eq!(1, m.len());
-    m.insert("second", 16);
-    assert_eq!(2, m.len());
-    m.insert("first", 16);
-    assert_eq!(2, m.len());
-}
-
-#[test]
-fn overwrites_keys() {
-    let mut m: Map<i32, i32, 1> = Map::new();
-    m.insert(1, 42);
-    m.insert(1, 42);
-    assert_eq!(1, m.len());
-}
-
-#[test]
-#[should_panic]
-#[cfg(debug_assertions)]
-fn cant_write_into_empty_map() {
-    let mut m: Map<i32, i32, 0> = Map::new();
-    m.insert(1, 42);
-}
-
-#[test]
-fn empty_length() {
-    let m: Map<u32, u32, 10> = Map::new();
-    assert_eq!(0, m.len());
-}
-
-#[test]
-fn is_empty_check() {
-    let mut m: Map<u32, u32, 10> = Map::new();
-    assert!(m.is_empty());
-    m.insert(42, 42);
-    assert!(!m.is_empty());
-}
-
-#[test]
-fn insert_and_gets() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    m.insert("one", 42);
-    m.insert("two", 16);
-    assert_eq!(16, *m.get(&"two").unwrap());
-}
-
-#[test]
-fn insert_and_gets_mut() {
-    let mut m: Map<i32, [i32; 3], 10> = Map::new();
-    m.insert(42, [1, 2, 3]);
-    let a = m.get_mut(&42).unwrap();
-    a[0] = 500;
-    assert_eq!(500, m.get(&42).unwrap()[0]);
-}
-
-#[test]
-fn checks_key() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    m.insert("one", 42);
-    assert!(m.contains_key(&"one"));
-    assert!(!m.contains_key(&"another"));
-}
-
-#[test]
-fn gets_missing_key() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    m.insert("one", 42);
-    assert!(m.get(&"two").is_none());
-}
-
-#[test]
-fn mut_gets_missing_key() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    m.insert("one", 42);
-    assert!(m.get_mut(&"two").is_none());
-}
-
-#[test]
-fn removes_simple_pair() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    m.insert("one", 42);
-    m.remove(&"one");
-    m.remove(&"another");
-    assert!(m.get(&"one").is_none());
-}
-
 #[cfg(test)]
-#[derive(Clone)]
-struct Foo {
-    v: [u32; 3],
-}
+mod test {
 
-#[test]
-fn insert_struct() {
-    let mut m: Map<u8, Foo, 8> = Map::new();
-    let foo = Foo { v: [1, 2, 100] };
-    m.insert(1, foo);
-    assert_eq!(100, m.into_iter().next().unwrap().1.v[2]);
-}
+    use super::*;
 
-#[cfg(test)]
-#[derive(Clone)]
-struct Composite {
-    r: Map<u8, u8, 1>,
-}
+    #[test]
+    fn insert_and_check_length() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        m.insert("first", 42);
+        assert_eq!(1, m.len());
+        m.insert("second", 16);
+        assert_eq!(2, m.len());
+        m.insert("first", 16);
+        assert_eq!(2, m.len());
+    }
 
-#[test]
-fn insert_composite() {
-    let mut m: Map<u8, Composite, 8> = Map::new();
-    let c = Composite { r: Map::new() };
-    m.insert(1, c);
-    assert_eq!(0, m.into_iter().next().unwrap().1.r.len());
-}
+    #[test]
+    fn overwrites_keys() {
+        let mut m: Map<i32, i32, 1> = Map::new();
+        m.insert(1, 42);
+        m.insert(1, 42);
+        assert_eq!(1, m.len());
+    }
 
-#[test]
-fn large_map_in_heap() {
-    let m: Box<Map<u64, [u64; 10], 10>> = Box::new(Map::new());
-    assert_eq!(0, m.len());
-}
+    #[test]
+    #[should_panic]
+    #[cfg(debug_assertions)]
+    fn cant_write_into_empty_map() {
+        let mut m: Map<i32, i32, 0> = Map::new();
+        m.insert(1, 42);
+    }
 
-#[test]
-fn clears_it_up() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    m.insert("one", 42);
-    m.clear();
-    assert_eq!(0, m.len());
-}
+    #[test]
+    fn empty_length() {
+        let m: Map<u32, u32, 10> = Map::new();
+        assert_eq!(0, m.len());
+    }
 
-#[test]
-fn retain_test() {
-    let vec: Vec<(i32, i32)> = (0..8).map(|x| (x, x * 10)).collect();
-    let mut m: Map<i32, i32, 10> = Map::from_iter(vec);
-    assert_eq!(m.len(), 8);
-    m.retain(|&k, _| k < 6);
-    assert_eq!(m.len(), 6);
-    m.retain(|_, &v| v > 30);
-    assert_eq!(m.len(), 2);
-}
+    #[test]
+    fn is_empty_check() {
+        let mut m: Map<u32, u32, 10> = Map::new();
+        assert!(m.is_empty());
+        m.insert(42, 42);
+        assert!(!m.is_empty());
+    }
 
-#[test]
-fn insert_many_and_remove() {
-    let mut m: Map<usize, u64, 4> = Map::new();
-    for _ in 0..2 {
-        let cap = m.capacity();
-        for i in 0..cap {
-            m.insert(i, 256);
-            m.remove(&i);
+    #[test]
+    fn insert_and_gets() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        m.insert("one", 42);
+        m.insert("two", 16);
+        assert_eq!(16, *m.get(&"two").unwrap());
+    }
+
+    #[test]
+    fn insert_and_gets_mut() {
+        let mut m: Map<i32, [i32; 3], 10> = Map::new();
+        m.insert(42, [1, 2, 3]);
+        let a = m.get_mut(&42).unwrap();
+        a[0] = 500;
+        assert_eq!(500, m.get(&42).unwrap()[0]);
+    }
+
+    #[test]
+    fn checks_key() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        m.insert("one", 42);
+        assert!(m.contains_key(&"one"));
+        assert!(!m.contains_key(&"another"));
+    }
+
+    #[test]
+    fn gets_missing_key() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        m.insert("one", 42);
+        assert!(m.get(&"two").is_none());
+    }
+
+    #[test]
+    fn mut_gets_missing_key() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        m.insert("one", 42);
+        assert!(m.get_mut(&"two").is_none());
+    }
+
+    #[test]
+    fn removes_simple_pair() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        m.insert("one", 42);
+        m.remove(&"one");
+        m.remove(&"another");
+        assert!(m.get(&"one").is_none());
+    }
+
+    #[cfg(test)]
+    #[derive(Clone)]
+    struct Foo {
+        v: [u32; 3],
+    }
+
+    #[test]
+    fn insert_struct() {
+        let mut m: Map<u8, Foo, 8> = Map::new();
+        let foo = Foo { v: [1, 2, 100] };
+        m.insert(1, foo);
+        assert_eq!(100, m.into_iter().next().unwrap().1.v[2]);
+    }
+
+    #[cfg(test)]
+    #[derive(Clone)]
+    struct Composite {
+        r: Map<u8, u8, 1>,
+    }
+
+    #[test]
+    fn insert_composite() {
+        let mut m: Map<u8, Composite, 8> = Map::new();
+        let c = Composite { r: Map::new() };
+        m.insert(1, c);
+        assert_eq!(0, m.into_iter().next().unwrap().1.r.len());
+    }
+
+    #[test]
+    fn large_map_in_heap() {
+        let m: Box<Map<u64, [u64; 10], 10>> = Box::new(Map::new());
+        assert_eq!(0, m.len());
+    }
+
+    #[test]
+    fn clears_it_up() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        m.insert("one", 42);
+        m.clear();
+        assert_eq!(0, m.len());
+    }
+
+    #[test]
+    fn retain_test() {
+        let vec: Vec<(i32, i32)> = (0..8).map(|x| (x, x * 10)).collect();
+        let mut m: Map<i32, i32, 10> = Map::from_iter(vec);
+        assert_eq!(m.len(), 8);
+        m.retain(|&k, _| k < 6);
+        assert_eq!(m.len(), 6);
+        m.retain(|_, &v| v > 30);
+        assert_eq!(m.len(), 2);
+    }
+
+    #[test]
+    fn insert_many_and_remove() {
+        let mut m: Map<usize, u64, 4> = Map::new();
+        for _ in 0..2 {
+            let cap = m.capacity();
+            for i in 0..cap {
+                m.insert(i, 256);
+                m.remove(&i);
+            }
         }
     }
-}
 
-#[test]
-fn get_key_value() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    let k = "key";
-    m.insert(k, 42);
-    assert_eq!(m.get_key_value(k), Some((&k, &42)));
-    assert!(m.contains_key(&k));
-}
+    #[test]
+    fn get_key_value() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        let k = "key";
+        m.insert(k, 42);
+        assert_eq!(m.get_key_value(k), Some((&k, &42)));
+        assert!(m.contains_key(&k));
+    }
 
-#[test]
-fn get_absent_key_value() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    m.insert("one", 42);
-    assert_eq!(m.get_key_value("two"), None);
-}
+    #[test]
+    fn get_absent_key_value() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        m.insert("one", 42);
+        assert_eq!(m.get_key_value("two"), None);
+    }
 
-#[test]
-fn remove_entry_present() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    let k = "key";
-    m.insert(k, 42);
-    assert_eq!(m.remove_entry(k), Some((k, 42)));
-    assert!(!m.contains_key(&k));
-}
+    #[test]
+    fn remove_entry_present() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        let k = "key";
+        m.insert(k, 42);
+        assert_eq!(m.remove_entry(k), Some((k, 42)));
+        assert!(!m.contains_key(&k));
+    }
 
-#[test]
-fn remove_entry_absent() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    m.insert("one", 42);
-    assert_eq!(m.remove_entry("two"), None);
-}
+    #[test]
+    fn remove_entry_absent() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        m.insert("one", 42);
+        assert_eq!(m.remove_entry("two"), None);
+    }
 
-#[test]
-fn drop_removed_entry() {
-    use std::rc::Rc;
-    let mut m: Map<(), Rc<()>, 8> = Map::new();
-    let v = Rc::new(());
-    m.insert((), Rc::clone(&v));
-    assert_eq!(Rc::strong_count(&v), 2);
-    m.remove_entry(&());
-    assert_eq!(Rc::strong_count(&v), 1);
-}
+    #[test]
+    fn drop_removed_entry() {
+        use std::rc::Rc;
+        let mut m: Map<(), Rc<()>, 8> = Map::new();
+        let v = Rc::new(());
+        m.insert((), Rc::clone(&v));
+        assert_eq!(Rc::strong_count(&v), 2);
+        m.remove_entry(&());
+        assert_eq!(Rc::strong_count(&v), 1);
+    }
 
-#[test]
-fn insert_after_remove() {
-    let mut m: Map<_, _, 1> = Map::new();
-    m.insert(1, 2);
-    m.remove(&1);
-    m.insert(1, 3);
-}
+    #[test]
+    fn insert_after_remove() {
+        let mut m: Map<_, _, 1> = Map::new();
+        m.insert(1, 2);
+        m.remove(&1);
+        m.insert(1, 3);
+    }
 
-#[test]
-fn insert_drop_duplicate() {
-    use std::rc::Rc;
-    let mut m: Map<_, _, 1> = Map::new();
-    let v = Rc::new(());
-    m.insert((), Rc::clone(&v));
-    assert_eq!(Rc::strong_count(&v), 2);
-    m.insert((), Rc::clone(&v));
-    assert_eq!(Rc::strong_count(&v), 2);
-}
+    #[test]
+    fn insert_drop_duplicate() {
+        use std::rc::Rc;
+        let mut m: Map<_, _, 1> = Map::new();
+        let v = Rc::new(());
+        m.insert((), Rc::clone(&v));
+        assert_eq!(Rc::strong_count(&v), 2);
+        m.insert((), Rc::clone(&v));
+        assert_eq!(Rc::strong_count(&v), 2);
+    }
 
-#[test]
-fn insert_duplicate_after_remove() {
-    let mut m: Map<_, _, 2> = Map::new();
-    m.insert(1, 1);
-    m.insert(2, 2);
-    m.remove(&1);
-    m.insert(2, 3);
-    assert_eq!(1, m.len());
-    assert_eq!(3, m[&2]);
+    #[test]
+    fn insert_duplicate_after_remove() {
+        let mut m: Map<_, _, 2> = Map::new();
+        m.insert(1, 1);
+        m.insert(2, 2);
+        m.remove(&1);
+        m.insert(2, 3);
+        assert_eq!(1, m.len());
+        assert_eq!(3, m[&2]);
+    }
 }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -19,11 +19,11 @@
 // SOFTWARE.
 
 use crate::Map;
+use core::fmt::Formatter;
+use core::marker::PhantomData;
 use serde::de::{MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt::Formatter;
-use std::marker::PhantomData;
 
 impl<K: PartialEq + Serialize, V: Serialize, const N: usize> Serialize for Map<K, V, N> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -45,7 +45,7 @@ impl<'de, K: PartialEq + Deserialize<'de>, V: Deserialize<'de>, const N: usize> 
 {
     type Value = Map<K, V, N>;
 
-    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
         formatter.write_str("a Map")
     }
 

--- a/src/values.rs
+++ b/src/values.rs
@@ -71,42 +71,48 @@ impl<K: PartialEq, V, const N: usize> Iterator for IntoValues<K, V, N> {
     }
 }
 
-#[test]
-fn iterate_values() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    m.insert("one", 42);
-    m.insert("two", 16);
-    assert_eq!(58, m.values().sum());
-}
+#[cfg(test)]
+mod test {
 
-#[test]
-fn iterate_values_mut() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    m.insert("one", 42);
-    m.insert("two", 16);
-    m.values_mut().for_each(|v| *v *= 2);
-    assert_eq!(116, m.values().sum());
-}
+    use super::*;
 
-#[test]
-fn iterate_values_with_blanks() {
-    let mut m: Map<&str, i32, 10> = Map::new();
-    m.insert("one", 1);
-    m.insert("two", 3);
-    m.insert("three", 5);
-    m.remove(&"two");
-    assert_eq!(m.values().collect::<Vec<_>>(), [&1, &5]);
-}
-
-#[test]
-fn into_values_drop() {
-    use std::rc::Rc;
-    let mut m: Map<i32, Rc<()>, 8> = Map::new();
-    let v = Rc::new(());
-    for i in 0..8 {
-        m.insert(i, Rc::clone(&v));
+    #[test]
+    fn iterate_values() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        m.insert("one", 42);
+        m.insert("two", 16);
+        assert_eq!(58, m.values().sum());
     }
-    assert_eq!(9, Rc::strong_count(&v));
-    m.into_values();
-    assert_eq!(1, Rc::strong_count(&v));
+
+    #[test]
+    fn iterate_values_mut() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        m.insert("one", 42);
+        m.insert("two", 16);
+        m.values_mut().for_each(|v| *v *= 2);
+        assert_eq!(116, m.values().sum());
+    }
+
+    #[test]
+    fn iterate_values_with_blanks() {
+        let mut m: Map<&str, i32, 10> = Map::new();
+        m.insert("one", 1);
+        m.insert("two", 3);
+        m.insert("three", 5);
+        m.remove(&"two");
+        assert_eq!(m.values().collect::<Vec<_>>(), [&1, &5]);
+    }
+
+    #[test]
+    fn into_values_drop() {
+        use std::rc::Rc;
+        let mut m: Map<i32, Rc<()>, 8> = Map::new();
+        let v = Rc::new(());
+        for i in 0..8 {
+            m.insert(i, Rc::clone(&v));
+        }
+        assert_eq!(9, Rc::strong_count(&v));
+        m.into_values();
+        assert_eq!(1, Rc::strong_count(&v));
+    }
 }


### PR DESCRIPTION
Fixes #107 

:crab: Idiomatic `no_std`:

- `no_std` by default unless `std` either enabled by non-default feature or via special `test` / `doc` `cfg()`
- units run always in `std` in host - re-organised them under `mod test` scope as usual

Also adds regular CI build-only-tests with the `thumbv7em-none-eabi` target which has no std to ensure it builds for `no_std`.