### PR TITLE
Optimisation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,41 +21,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
-name = "arrayref"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "blake2b_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
 ]
 
 [[package]]
@@ -71,56 +42,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "clippy"
-version = "0.0.302"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d911ee15579a3f50880d8c1d59ef6e79f9533127a3bd342462f5d584f5e8c294"
-dependencies = [
- "term",
-]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d96137f14f244c37f989d9fff8f95e6c18b918e71f36638f8c49112e4c78f"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "dirs"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
 
 [[package]]
 name = "hash32"
@@ -162,12 +87,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.151"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
-
-[[package]]
 name = "linear-map"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,7 +109,6 @@ name = "micromap"
 version = "0.0.0"
 dependencies = [
  "bincode",
- "clippy",
  "hashbrown",
  "heapless",
  "indexmap",
@@ -231,35 +149,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_users"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
-dependencies = [
- "getrandom",
- "redox_syscall",
- "rust-argon2",
-]
-
-[[package]]
-name = "rust-argon2"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
-dependencies = [
- "base64",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -306,17 +195,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
-dependencies = [
- "byteorder",
- "dirs",
- "winapi",
-]
-
-[[package]]
 name = "tinymap"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,34 +220,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ serde = { version = "1.0.193", optional = true, default-features = false }
 
 [dev-dependencies]
 bincode = "1.3.3"
-clippy = "0.0.302"
 hashbrown = "0.14.0"
 heapless = "0.8.0"
 rustc-hash = "1.1.0"

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -23,9 +23,10 @@ use crate::Map;
 impl<K: Clone + PartialEq, V: Clone, const N: usize> Clone for Map<K, V, N> {
     fn clone(&self) -> Self {
         let mut m: Self = Self::new();
-        for (k, v) in self {
-            m.insert(k.clone(), v.clone());
+        for i in 0..self.len {
+            m.item_write(i, self.item_ref(i).clone());
         }
+        m.len = self.len;
         m
     }
 }

--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -41,8 +41,8 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     pub const fn new() -> Self {
         unsafe {
             Self {
-                next: 0,
-                pairs: MaybeUninit::<[MaybeUninit<Option<(K, V)>>; N]>::uninit().assume_init(),
+                len: 0,
+                pairs: MaybeUninit::<[MaybeUninit<(K, V)>; N]>::uninit().assume_init(),
             }
         }
     }
@@ -50,7 +50,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
 
 impl<K: PartialEq, V, const N: usize> Drop for Map<K, V, N> {
     fn drop(&mut self) {
-        for i in 0..self.next {
+        for i in 0..self.len {
             self.item_drop(i);
         }
     }

--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -51,9 +51,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
 impl<K: PartialEq, V, const N: usize> Drop for Map<K, V, N> {
     fn drop(&mut self) {
         for i in 0..self.next {
-            unsafe {
-                self.pairs[i].assume_init_drop();
-            }
+            self.item_drop(i);
         }
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -19,11 +19,24 @@
 // SOFTWARE.
 
 use crate::Map;
-use core::fmt::{self, Debug, Formatter};
+use core::fmt::{self, Display, Formatter, Write};
 
-impl<K: PartialEq + Debug, V: Debug, const N: usize> Debug for Map<K, V, N> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        f.debug_map().entries(self.iter()).finish()
+impl<K: PartialEq + Display, V: Display, const N: usize> Display for Map<K, V, N> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut first = true;
+        f.write_char('{')?;
+        for (k, v) in self {
+            if first {
+                first = false;
+            } else {
+                f.write_str(", ")?;
+            }
+            k.fmt(f)?;
+            f.write_str(": ")?;
+            v.fmt(f)?;
+        }
+        f.write_char('}')?;
+        Ok(())
     }
 }
 
@@ -33,24 +46,10 @@ mod test {
     use super::*;
 
     #[test]
-    fn debugs_map() {
+    fn displays_map() {
         let mut m: Map<String, i32, 10> = Map::new();
         m.insert("one".to_string(), 42);
         m.insert("two".to_string(), 16);
-        assert_eq!(r#"{"one": 42, "two": 16}"#, format!("{:?}", m));
-    }
-
-    #[test]
-    fn debug_alternate_map() {
-        let mut m: Map<String, i32, 10> = Map::new();
-        m.insert("one".to_string(), 42);
-        m.insert("two".to_string(), 16);
-        assert_eq!(
-            r#"{
-    "one": 42,
-    "two": 16,
-}"#,
-            format!("{:#?}", m)
-        );
+        assert_eq!(r#"{one: 42, two: 16}"#, format!("{}", m));
     }
 }

--- a/src/eq.rs
+++ b/src/eq.rs
@@ -30,14 +30,14 @@ impl<K: PartialEq, V: PartialEq, const N: usize> PartialEq for Map<K, V, N> {
     /// let mut m2: micromap::Map<u8, i32, 10> = micromap::Map::new();
     /// m1.insert(1, 42);
     /// m2.insert(1, 42);
-    /// #[cfg(std)]
+    /// # #[cfg(std)]
     /// assert_eq!(m1, m2);
     /// // two maps with different order of key-value pairs are still equal:
     /// m1.insert(2, 1);
     /// m1.insert(3, 16);
     /// m2.insert(3, 16);
     /// m2.insert(2, 1);
-    /// #[cfg(std)]
+    /// # #[cfg(std)]
     /// assert_eq!(m1, m2);
     /// ```
     #[inline]

--- a/src/index.rs
+++ b/src/index.rs
@@ -22,7 +22,9 @@ use crate::Map;
 use core::borrow::Borrow;
 use core::ops::{Index, IndexMut};
 
-impl<K: Eq + Borrow<Q>, Q: Eq + ?Sized, V, const N: usize> Index<&Q> for Map<K, V, N> {
+impl<K: PartialEq + Borrow<Q>, Q: PartialEq + ?Sized, V, const N: usize> Index<&Q>
+    for Map<K, V, N>
+{
     type Output = V;
 
     #[inline]
@@ -32,7 +34,9 @@ impl<K: Eq + Borrow<Q>, Q: Eq + ?Sized, V, const N: usize> Index<&Q> for Map<K, 
     }
 }
 
-impl<K: Eq + Borrow<Q>, Q: Eq + ?Sized, V, const N: usize> IndexMut<&Q> for Map<K, V, N> {
+impl<K: PartialEq + Borrow<Q>, Q: PartialEq + ?Sized, V, const N: usize> IndexMut<&Q>
+    for Map<K, V, N>
+{
     #[inline]
     #[must_use]
     fn index_mut(&mut self, key: &Q) -> &mut V {
@@ -69,7 +73,7 @@ mod test {
     }
 
     #[cfg(test)]
-    #[derive(PartialEq, Eq)]
+    #[derive(PartialEq)]
     struct Container {
         pub t: i32,
     }

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -85,7 +85,7 @@ impl<K: PartialEq, V, const N: usize> Iterator for IntoIter<K, V, N> {
     #[must_use]
     fn next(&mut self) -> Option<Self::Item> {
         while self.pos < self.map.next {
-            let p = &mut self.map.pairs[self.pos];
+            let p = self.map.item(self.pos);
             self.pos += 1;
             unsafe {
                 if p.assume_init_ref().is_some() {

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -27,17 +27,13 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     #[inline]
     #[must_use]
     pub fn iter(&self) -> Iter<K, V> {
-        Iter {
-            iter: self.pairs[0..self.len].iter(),
-        }
+        self.into_iter()
     }
 
     /// An iterator with mutable references to the values but
     #[inline]
     pub fn iter_mut(&mut self) -> IterMut<K, V> {
-        IterMut {
-            iter: self.pairs[0..self.len].iter_mut(),
-        }
+        self.into_iter()
     }
 }
 
@@ -89,7 +85,9 @@ impl<'a, K: PartialEq, V, const N: usize> IntoIterator for &'a Map<K, V, N> {
     #[inline]
     #[must_use]
     fn into_iter(self) -> Self::IntoIter {
-        self.iter()
+        Iter {
+            iter: self.pairs[0..self.len].iter(),
+        }
     }
 }
 
@@ -99,7 +97,9 @@ impl<'a, K: PartialEq, V, const N: usize> IntoIterator for &'a mut Map<K, V, N> 
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        self.iter_mut()
+        IterMut {
+            iter: self.pairs[0..self.len].iter_mut(),
+        }
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -19,6 +19,7 @@
 // SOFTWARE.
 
 use crate::{IntoKeys, Keys, Map};
+use core::iter::FusedIterator;
 
 impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     /// An iterator visiting all keys in arbitrary order.
@@ -53,6 +54,34 @@ impl<K: PartialEq, V, const N: usize> Iterator for IntoKeys<K, V, N> {
         self.iter.next().map(|p| p.0)
     }
 }
+
+impl<'a, K, V> DoubleEndedIterator for Keys<'a, K, V> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(|p| p.0)
+    }
+}
+
+impl<K: PartialEq, V, const N: usize> DoubleEndedIterator for IntoKeys<K, V, N> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(|p| p.0)
+    }
+}
+
+impl<'a, K, V> ExactSizeIterator for Keys<'a, K, V> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
+impl<K: PartialEq, V, const N: usize> ExactSizeIterator for IntoKeys<K, V, N> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
+impl<'a, K, V> FusedIterator for Keys<'a, K, V> {}
+
+impl<K: PartialEq, V, const N: usize> FusedIterator for IntoKeys<K, V, N> {}
 
 #[cfg(test)]
 mod test {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -23,7 +23,7 @@ use crate::{IntoKeys, Keys, Map};
 impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     /// An iterator visiting all keys in arbitrary order.
     #[inline]
-    pub const fn keys(&self) -> Keys<'_, K, V, N> {
+    pub fn keys(&self) -> Keys<'_, K, V> {
         Keys { iter: self.iter() }
     }
 
@@ -36,7 +36,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     }
 }
 
-impl<'a, K: PartialEq, V, const N: usize> Iterator for Keys<'a, K, V, N> {
+impl<'a, K, V> Iterator for Keys<'a, K, V> {
     type Item = &'a K;
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,19 +99,14 @@ pub struct Map<K: PartialEq, V, const N: usize> {
 }
 
 /// Iterator over the [`Map`].
-pub struct Iter<'a, K, V, const N: usize> {
-    /// The next available pair in the array.
-    next: usize,
-    /// The next position in the iterator to read.
-    pos: usize,
-    /// The fixed-size array of key-value pairs.
-    pairs: &'a [MaybeUninit<(K, V)>; N],
+#[repr(transparent)]
+pub struct Iter<'a, K, V> {
+    iter: core::slice::Iter<'a, MaybeUninit<(K, V)>>,
 }
 
 /// Mutable Iterator over the [`Map`].
+#[repr(transparent)]
 pub struct IterMut<'a, K, V> {
-    next: usize,
-    pos: usize,
     iter: core::slice::IterMut<'a, MaybeUninit<(K, V)>>,
 }
 
@@ -122,26 +117,31 @@ pub struct IntoIter<K: PartialEq, V, const N: usize> {
 }
 
 /// An iterator over the values of the [`Map`].
-pub struct Values<'a, K: PartialEq, V, const N: usize> {
-    iter: Iter<'a, K, V, N>,
+#[repr(transparent)]
+pub struct Values<'a, K, V> {
+    iter: Iter<'a, K, V>,
 }
 
 /// Mutable iterator over the values of the [`Map`].
-pub struct ValuesMut<'a, K: PartialEq, V> {
+#[repr(transparent)]
+pub struct ValuesMut<'a, K, V> {
     iter: IterMut<'a, K, V>,
 }
 
 /// Consuming iterator over the values of the [`Map`].
+#[repr(transparent)]
 pub struct IntoValues<K: PartialEq, V, const N: usize> {
     iter: IntoIter<K, V, N>,
 }
 
 /// A read-only iterator over the keys of the [`Map`].
-pub struct Keys<'a, K: PartialEq, V, const N: usize> {
-    iter: Iter<'a, K, V, N>,
+#[repr(transparent)]
+pub struct Keys<'a, K, V> {
+    iter: Iter<'a, K, V>,
 }
 
 /// Consuming iterator over the keys of the [`Map`].
+#[repr(transparent)]
 pub struct IntoKeys<K: PartialEq, V, const N: usize> {
     iter: IntoIter<K, V, N>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,8 +62,10 @@ mod keys;
 mod map;
 #[cfg(feature = "serde")]
 mod serialization;
+mod set;
 mod values;
 
+pub use crate::set::{Set, SetIntoIter, SetIter};
 use core::mem::{ManuallyDrop, MaybeUninit};
 
 /// A faster alternative of [`std::collections::HashMap`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 //! let mut m : Map<u64, &str, 10> = Map::new();
 //! m.insert(1, "Hello, world!");
 //! m.insert(2, "Good bye!");
-//! #[cfg(std)]
+//! # #[cfg(std)]
 //! assert_eq!(2, m.len());
 //! ```
 //!
@@ -76,7 +76,7 @@ use core::mem::MaybeUninit;
 /// let mut m : micromap::Map<u64, &str, 8> = micromap::Map::new();
 /// m.insert(1, "Jeff Lebowski");
 /// m.insert(2, "Walter Sobchak");
-/// #[cfg(std)]
+/// # #[cfg(std)]
 /// assert_eq!(2, m.len());
 /// ```
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,11 +50,10 @@
 #![allow(clippy::multiple_inherent_impl)]
 #![allow(clippy::multiple_crate_versions)]
 
-#[cfg(feature = "std")]
-mod debug;
-
 mod clone;
 mod ctors;
+mod debug;
+mod display;
 mod eq;
 mod from;
 mod index;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ mod map;
 mod serialization;
 mod values;
 
-use core::mem::MaybeUninit;
+use core::mem::{ManuallyDrop, MaybeUninit};
 
 /// A faster alternative of [`std::collections::HashMap`].
 ///
@@ -93,9 +93,9 @@ use core::mem::MaybeUninit;
 /// are disabled, for the sake of higher performance.
 pub struct Map<K: PartialEq, V, const N: usize> {
     /// The next available pair in the array.
-    next: usize,
+    len: usize,
     /// The fixed-size array of key-value pairs.
-    pairs: [MaybeUninit<Option<(K, V)>>; N],
+    pairs: [MaybeUninit<(K, V)>; N],
 }
 
 /// Iterator over the [`Map`].
@@ -105,20 +105,20 @@ pub struct Iter<'a, K, V, const N: usize> {
     /// The next position in the iterator to read.
     pos: usize,
     /// The fixed-size array of key-value pairs.
-    pairs: &'a [MaybeUninit<Option<(K, V)>>; N],
+    pairs: &'a [MaybeUninit<(K, V)>; N],
 }
 
 /// Mutable Iterator over the [`Map`].
 pub struct IterMut<'a, K, V> {
     next: usize,
     pos: usize,
-    iter: core::slice::IterMut<'a, MaybeUninit<Option<(K, V)>>>,
+    iter: core::slice::IterMut<'a, MaybeUninit<(K, V)>>,
 }
 
 /// Into-iterator over the [`Map`].
 pub struct IntoIter<K: PartialEq, V, const N: usize> {
     pos: usize,
-    map: Map<K, V, N>,
+    map: ManuallyDrop<Map<K, V, N>>,
 }
 
 /// An iterator over the values of the [`Map`].

--- a/src/map.rs
+++ b/src/map.rs
@@ -59,8 +59,8 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
         K: Borrow<Q>,
     {
         for i in 0..self.next {
-            if let Some((bk, _bv)) = self.item(i) {
-                if bk.borrow() == k {
+            if let Some(p) = self.item(i) {
+                if p.0.borrow() == k {
                     return true;
                 }
             }
@@ -177,8 +177,8 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     #[inline]
     pub fn retain<F: Fn(&K, &V) -> bool>(&mut self, f: F) {
         for i in 0..self.next {
-            if let Some((k, v)) = self.item(i) {
-                if !f(k, v) {
+            if let Some(p) = self.item(i) {
+                if !f(&p.0, &p.1) {
                     self.pairs[i].write(None);
                 }
             }

--- a/src/map.rs
+++ b/src/map.rs
@@ -44,7 +44,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     pub fn len(&self) -> usize {
         let mut busy = 0;
         for i in 0..self.next {
-            if self.item(i).is_some() {
+            if self.item_ref(i).is_some() {
                 busy += 1;
             }
         }
@@ -59,7 +59,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
         K: Borrow<Q>,
     {
         for i in 0..self.next {
-            if let Some(p) = self.item(i) {
+            if let Some(p) = self.item_ref(i) {
                 if p.0.borrow() == k {
                     return true;
                 }
@@ -75,7 +75,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
         K: Borrow<Q>,
     {
         for i in 0..self.next {
-            if let Some(p) = self.item(i) {
+            if let Some(p) = self.item_ref(i) {
                 if p.0.borrow() == k {
                     unsafe { self.pairs[i].assume_init_drop() };
                     self.pairs[i].write(None);
@@ -103,7 +103,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
                 debug_assert!(target < N, "No more keys available in the map");
                 break;
             }
-            match self.item(i) {
+            match self.item_ref(i) {
                 Some(p) => {
                     if p.0 == k {
                         target = i;
@@ -133,7 +133,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
         K: Borrow<Q>,
     {
         for i in 0..self.next {
-            if let Some(p) = self.item(i) {
+            if let Some(p) = self.item_ref(i) {
                 if p.0.borrow() == k {
                     return Some(&p.1);
                 }
@@ -154,7 +154,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
         K: Borrow<Q>,
     {
         for i in 0..self.next {
-            if let Some(p1) = self.item(i) {
+            if let Some(p1) = self.item_ref(i) {
                 if p1.0.borrow() == k {
                     let p2 = unsafe { self.pairs[i].assume_init_mut() };
                     return Some(&mut p2.as_mut().unwrap().1);
@@ -177,7 +177,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     #[inline]
     pub fn retain<F: Fn(&K, &V) -> bool>(&mut self, f: F) {
         for i in 0..self.next {
-            if let Some(p) = self.item(i) {
+            if let Some(p) = self.item_ref(i) {
                 if !f(&p.0, &p.1) {
                     self.pairs[i].write(None);
                 }
@@ -187,7 +187,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
 
     /// Internal function to get access to the element in the internal array.
     #[inline]
-    const fn item(&self, i: usize) -> &Option<(K, V)> {
+    const fn item_ref(&self, i: usize) -> &Option<(K, V)> {
         unsafe { self.pairs[i].assume_init_ref() }
     }
 
@@ -198,7 +198,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
         K: Borrow<Q>,
     {
         for i in 0..self.next {
-            if let Some(p) = self.item(i) {
+            if let Some(p) = self.item_ref(i) {
                 if p.0.borrow() == k {
                     return Some((&p.0, &p.1));
                 }
@@ -215,7 +215,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
         K: Borrow<Q>,
     {
         for i in 0..self.next {
-            if let Some(p) = self.item(i) {
+            if let Some(p) = self.item_ref(i) {
                 if p.0.borrow() == k {
                     let ret = mem::replace(&mut self.pairs[i], MaybeUninit::new(None));
                     unsafe {

--- a/src/set/clone.rs
+++ b/src/set/clone.rs
@@ -1,0 +1,29 @@
+// Copyright (c) 2023 Yegor Bugayenko
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use crate::Set;
+
+impl<T: Clone + PartialEq, const N: usize> Clone for Set<T, N> {
+    fn clone(&self) -> Self {
+        Self {
+            map: self.map.clone(),
+        }
+    }
+}

--- a/src/set/ctors.rs
+++ b/src/set/ctors.rs
@@ -1,0 +1,45 @@
+// Copyright (c) 2023 Yegor Bugayenko
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use crate::{Map, Set};
+
+impl<T: PartialEq, const N: usize> Default for Set<T, N> {
+    /// Make a default empty [`Set`].
+    #[inline]
+    #[must_use]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: PartialEq, const N: usize> Set<T, N> {
+    /// Make it.
+    ///
+    /// The size of the set is defined by the generic argument. For example,
+    /// this is how you make a set of four key-values pairs:
+    #[inline]
+    #[must_use]
+    #[allow(clippy::uninit_assumed_init)]
+    pub const fn new() -> Self {
+        Self {
+            map: Map::<T, (), N>::new(),
+        }
+    }
+}

--- a/src/set/debug.rs
+++ b/src/set/debug.rs
@@ -1,0 +1,56 @@
+// Copyright (c) 2023 Yegor Bugayenko
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use crate::Set;
+use core::fmt::{self, Debug, Formatter};
+
+impl<T: PartialEq + Debug, const N: usize> Debug for Set<T, N> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_set().entries(self.iter()).finish()
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn debugs_set() {
+        let mut m: Set<String, 10> = Set::new();
+        m.insert("one".to_string());
+        m.insert("two".to_string());
+        assert_eq!(r#"{"one", "two"}"#, format!("{:?}", m));
+    }
+
+    #[test]
+    fn debug_alternate_set() {
+        let mut m: Set<String, 10> = Set::new();
+        m.insert("one".to_string());
+        m.insert("two".to_string());
+        assert_eq!(
+            r#"{
+    "one",
+    "two",
+}"#,
+            format!("{:#?}", m)
+        );
+    }
+}

--- a/src/set/display.rs
+++ b/src/set/display.rs
@@ -1,0 +1,53 @@
+// Copyright (c) 2023 Yegor Bugayenko
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use crate::Set;
+use core::fmt::{self, Display, Formatter, Write};
+
+impl<T: PartialEq + Display, const N: usize> Display for Set<T, N> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut first = true;
+        f.write_char('{')?;
+        for k in self {
+            if first {
+                first = false;
+            } else {
+                f.write_str(", ")?;
+            }
+            k.fmt(f)?;
+        }
+        f.write_char('}')?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn displays_set() {
+        let mut m: Set<String, 10> = Set::new();
+        m.insert("one".to_string());
+        m.insert("two".to_string());
+        assert_eq!(r#"{"one", "two"}"#, format!("{:?}", m));
+    }
+}

--- a/src/set/eq.rs
+++ b/src/set/eq.rs
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 Yegor Bugayenko
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use crate::Set;
+
+impl<T: PartialEq, const N: usize> PartialEq for Set<T, N> {
+    /// Two sets can be compared.
+    ///
+    /// For example:
+    ///
+    /// ```
+    /// let mut m1: micromap::Set<u8, 10> = micromap::Set::new();
+    /// let mut m2: micromap::Set<u8, 10> = micromap::Set::new();
+    /// m1.insert(1);
+    /// m2.insert(1);
+    /// # #[cfg(std)]
+    /// assert_eq!(m1, m2);
+    /// // two sets with different order of key-value pairs are still equal:
+    /// m1.insert(2);
+    /// m1.insert(3);
+    /// m2.insert(3);
+    /// m2.insert(2);
+    /// # #[cfg(std)]
+    /// assert_eq!(m1, m2);
+    /// ```
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.map.eq(&other.map)
+    }
+}
+
+impl<T: Eq, const N: usize> Eq for Set<T, N> {}

--- a/src/set/from.rs
+++ b/src/set/from.rs
@@ -1,0 +1,41 @@
+// Copyright (c) 2023 Yegor Bugayenko
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use crate::Set;
+
+impl<T: PartialEq, const N: usize> FromIterator<T> for Set<T, N> {
+    #[inline]
+    #[must_use]
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut s: Self = Self::new();
+        for k in iter {
+            s.insert(k);
+        }
+        s
+    }
+}
+
+impl<T: PartialEq, const N: usize> From<[T; N]> for Set<T, N> {
+    #[inline]
+    #[must_use]
+    fn from(arr: [T; N]) -> Self {
+        Self::from_iter(arr)
+    }
+}

--- a/src/set/functions.rs
+++ b/src/set/functions.rs
@@ -1,0 +1,109 @@
+// Copyright (c) 2023 Yegor Bugayenko
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use crate::Set;
+use core::borrow::Borrow;
+
+impl<T: PartialEq, const N: usize> Set<T, N> {
+    /// Get its total capacity.
+    #[inline]
+    #[must_use]
+    pub const fn capacity(&self) -> usize {
+        self.map.capacity()
+    }
+
+    /// Is it empty?
+    #[inline]
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// Return the total number of pairs inside.
+    #[inline]
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// Does the set contain this key?
+    #[inline]
+    #[must_use]
+    pub fn contains_key<Q: PartialEq + ?Sized>(&self, k: &Q) -> bool
+    where
+        T: Borrow<Q>,
+    {
+        self.map.contains_key(k)
+    }
+
+    /// Remove by key.
+    #[inline]
+    pub fn remove<Q: PartialEq + ?Sized>(&mut self, k: &Q)
+    where
+        T: Borrow<Q>,
+    {
+        self.map.remove(k);
+    }
+
+    /// Insert a single pair into the set.
+    ///
+    /// # Panics
+    ///
+    /// It may panic if there are too many pairs in the set already. Pay attention,
+    /// it panics only in the "debug" mode. In the "release" mode, you are going to get
+    /// undefined behavior. This is done for the sake of performance, in order to
+    /// avoid a repetitive check for the boundary condition on every `insert()`.
+    #[inline]
+    pub fn insert(&mut self, k: T) {
+        self.map.insert(k, ());
+    }
+
+    /// Get a reference to a single value.
+    #[inline]
+    #[must_use]
+    pub fn get<Q: PartialEq + ?Sized>(&self, k: &Q) -> Option<&T>
+    where
+        T: Borrow<Q>,
+    {
+        self.map.get_key_value(k).map(|p| p.0)
+    }
+
+    /// Remove all pairs from it, but keep the space intact for future use.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.map.clear();
+    }
+
+    /// Retains only the elements specified by the predicate.
+    #[inline]
+    pub fn retain<F: Fn(&T) -> bool>(&mut self, f: F) {
+        self.map.retain(|k, ()| f(k));
+    }
+
+    /// Removes a key from the set, returning the stored key and value if the
+    /// key was previously in the set.
+    #[inline]
+    pub fn take<Q: PartialEq + ?Sized>(&mut self, k: &Q) -> Option<T>
+    where
+        T: Borrow<Q>,
+    {
+        self.map.remove_entry(k).map(|p| p.0)
+    }
+}

--- a/src/set/iterators.rs
+++ b/src/set/iterators.rs
@@ -1,0 +1,105 @@
+// Copyright (c) 2023 Yegor Bugayenko
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use crate::set::{Set, SetIntoIter, SetIter};
+use core::iter::FusedIterator;
+
+impl<T: PartialEq, const N: usize> Set<T, N> {
+    /// Make an iterator over all pairs.
+    #[inline]
+    #[must_use]
+    pub fn iter(&self) -> SetIter<T> {
+        SetIter {
+            iter: self.map.keys(),
+        }
+    }
+}
+
+impl<'a, T> Iterator for SetIter<'a, T> {
+    type Item = &'a T;
+
+    #[inline]
+    #[must_use]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+}
+
+impl<T: PartialEq, const N: usize> Iterator for SetIntoIter<T, N> {
+    type Item = T;
+
+    #[inline]
+    #[must_use]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+}
+
+impl<'a, T: PartialEq, const N: usize> IntoIterator for &'a Set<T, N> {
+    type Item = &'a T;
+    type IntoIter = SetIter<'a, T>;
+
+    #[inline]
+    #[must_use]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<T: PartialEq, const N: usize> IntoIterator for Set<T, N> {
+    type Item = T;
+    type IntoIter = SetIntoIter<T, N>;
+
+    #[inline]
+    #[must_use]
+    fn into_iter(self) -> Self::IntoIter {
+        SetIntoIter {
+            iter: self.map.into_keys(),
+        }
+    }
+}
+
+impl<'a, T> DoubleEndedIterator for SetIter<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back()
+    }
+}
+
+impl<T: PartialEq, const N: usize> DoubleEndedIterator for SetIntoIter<T, N> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back()
+    }
+}
+
+impl<'a, T> ExactSizeIterator for SetIter<'a, T> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
+impl<T: PartialEq, const N: usize> ExactSizeIterator for SetIntoIter<T, N> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
+impl<'a, T> FusedIterator for SetIter<'a, T> {}
+
+impl<T: PartialEq, const N: usize> FusedIterator for SetIntoIter<T, N> {}

--- a/src/set/mod.rs
+++ b/src/set/mod.rs
@@ -1,0 +1,56 @@
+mod clone;
+mod ctors;
+mod debug;
+mod display;
+mod eq;
+mod from;
+mod functions;
+mod iterators;
+#[cfg(feature = "serde")]
+mod serialization;
+
+use crate::Map;
+
+/// A faster alternative of [`std::collections::HashSet`].
+///
+/// For example, this is how you make a set, which is allocated on stack and is capable of storing
+/// up to eight key-values pairs:
+///
+/// ```
+/// let mut m : micromap::Set<u64, 8> = micromap::Set::new();
+/// m.insert(1);
+/// m.insert(2);
+/// # #[cfg(std)]
+/// assert_eq!(2, m.len());
+/// ```
+///
+/// It is faster because it doesn't use a hash function at all. It simply keeps
+/// all pairs in an array and when it's necessary to find a value, it goes through
+/// all pairs comparing the needle with each pair available. Also it is faster
+/// because it doesn't use heap. When a [`Set`] is being created, it allocates the necessary
+/// space on stack. That's why the maximum size of the set must be provided in
+/// compile time.
+///
+/// It is also faster because it doesn't grow in size. When a [`Set`] is created,
+/// its size is fixed on stack. If an attempt is made to insert too many keys
+/// into it, it simply panics. Moreover, in the "release" mode it doesn't panic,
+/// but its behaviour is undefined. In the "release" mode all boundary checks
+/// are disabled, for the sake of higher performance.
+#[repr(transparent)]
+pub struct Set<T: PartialEq, const N: usize> {
+    map: Map<T, (), N>,
+}
+
+/// Iterator over the [`Set`].
+#[repr(transparent)]
+#[allow(clippy::module_name_repetitions)]
+pub struct SetIter<'a, T> {
+    iter: crate::Keys<'a, T, ()>,
+}
+
+/// Into-iterator over the [`Set`].
+#[repr(transparent)]
+#[allow(clippy::module_name_repetitions)]
+pub struct SetIntoIter<T: PartialEq, const N: usize> {
+    iter: crate::IntoKeys<T, (), N>,
+}

--- a/src/set/serialization.rs
+++ b/src/set/serialization.rs
@@ -1,0 +1,89 @@
+// Copyright (c) 2023 Yegor Bugayenko
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use crate::Set;
+use core::fmt::Formatter;
+use core::marker::PhantomData;
+use serde::de::{SeqAccess, Visitor};
+use serde::ser::SerializeSeq;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+impl<T: PartialEq + Serialize, const N: usize> Serialize for Set<T, N> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.len()))?;
+        for k in self.iter() {
+            seq.serialize_element(k)?;
+        }
+        seq.end()
+    }
+}
+
+struct Vi<T, const N: usize>(PhantomData<T>);
+
+impl<'de, T: PartialEq + Deserialize<'de>, const N: usize> Visitor<'de> for Vi<T, N> {
+    type Value = Set<T, N>;
+
+    fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
+        formatter.write_str("a Set")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut m: Self::Value = Set::new();
+        while let Some(key) = seq.next_element()? {
+            m.insert(key);
+        }
+        Ok(m)
+    }
+}
+
+impl<'de, T: PartialEq + Deserialize<'de>, const N: usize> Deserialize<'de> for Set<T, N> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_seq(Vi(PhantomData))
+    }
+}
+
+#[cfg(test)]
+use bincode::{deserialize, serialize};
+
+#[test]
+fn serialize_and_deserialize() {
+    let mut before: Set<u8, 8> = Set::new();
+    before.insert(1);
+    let bytes: Vec<u8> = serialize(&before).unwrap();
+    let after: Set<u8, 8> = deserialize(&bytes).unwrap();
+    assert_eq!(1, after.into_iter().next().unwrap());
+}
+
+#[test]
+fn empty_set_serde() {
+    let before: Set<u8, 8> = Set::new();
+    let bytes: Vec<u8> = serialize(&before).unwrap();
+    let after: Set<u8, 8> = deserialize(&bytes).unwrap();
+    assert!(after.is_empty());
+}

--- a/src/values.rs
+++ b/src/values.rs
@@ -19,6 +19,7 @@
 // SOFTWARE.
 
 use crate::{IntoValues, Map, Values, ValuesMut};
+use core::iter::FusedIterator;
 
 impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     /// An iterator visiting all values in arbitrary order.
@@ -70,6 +71,48 @@ impl<K: PartialEq, V, const N: usize> Iterator for IntoValues<K, V, N> {
         self.iter.next().map(|p| p.1)
     }
 }
+
+impl<'a, K, V> DoubleEndedIterator for Values<'a, K, V> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(|p| p.1)
+    }
+}
+
+impl<'a, K, V> DoubleEndedIterator for ValuesMut<'a, K, V> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(|p| p.1)
+    }
+}
+
+impl<K: PartialEq, V, const N: usize> DoubleEndedIterator for IntoValues<K, V, N> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(|p| p.1)
+    }
+}
+
+impl<'a, K, V> ExactSizeIterator for Values<'a, K, V> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
+impl<'a, K, V> ExactSizeIterator for ValuesMut<'a, K, V> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
+impl<K: PartialEq, V, const N: usize> ExactSizeIterator for IntoValues<K, V, N> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
+impl<'a, K, V> FusedIterator for Values<'a, K, V> {}
+
+impl<'a, K, V> FusedIterator for ValuesMut<'a, K, V> {}
+
+impl<K: PartialEq, V, const N: usize> FusedIterator for IntoValues<K, V, N> {}
 
 #[cfg(test)]
 mod test {

--- a/src/values.rs
+++ b/src/values.rs
@@ -23,7 +23,7 @@ use crate::{IntoValues, Map, Values, ValuesMut};
 impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     /// An iterator visiting all values in arbitrary order.
     #[inline]
-    pub const fn values(&self) -> Values<'_, K, V, N> {
+    pub fn values(&self) -> Values<'_, K, V> {
         Values { iter: self.iter() }
     }
 
@@ -44,7 +44,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     }
 }
 
-impl<'a, K: PartialEq, V, const N: usize> Iterator for Values<'a, K, V, N> {
+impl<'a, K, V> Iterator for Values<'a, K, V> {
     type Item = &'a V;
 
     #[inline]
@@ -53,7 +53,7 @@ impl<'a, K: PartialEq, V, const N: usize> Iterator for Values<'a, K, V, N> {
     }
 }
 
-impl<'a, K: PartialEq, V> Iterator for ValuesMut<'a, K, V> {
+impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
     type Item = &'a mut V;
 
     #[inline]

--- a/tests/benchmark.rs
+++ b/tests/benchmark.rs
@@ -144,9 +144,10 @@ fn benchmark(total: usize) -> HashMap<&'static str, Duration> {
 /// Run it like this from the command line:
 ///
 /// ```text
-/// $ cargo test --release benchmark_and_print -- --nocapture
+/// $ cargo test --test benchmark -- --include-ignored --nocapture
 /// ```
 #[test]
+#[ignore]
 pub fn benchmark_and_print() {
     let times = benchmark(
         #[cfg(debug_assertions)]


### PR DESCRIPTION
- Implements: #23, #26 
- Debug uses the debug fmt functions
- Display&Debug no longer require std
- Indexing no longer requires K to be Eq (just PartialEq, as everything else)
- All Iters are now also: DoubleEnded, ExactSize and Fused

Warning this is a breaking change since some of the Iter types change and the iter functions are no longer const (but others are).

Set Iter's uses slightly uncommon name. But the only way to go around it would be to export the set module and not via lib.

If you don't like parts of it, just tell me and I'll remove them.

I've also noticed that some, but not all, similar functions have `must_use`. And The functions names/types sometimes differ from HashMap.