### PR TITLE
Optimisation

### DIFF
--- a/src/drain.rs
+++ b/src/drain.rs
@@ -1,0 +1,54 @@
+// Copyright (c) 2024 Yegor Bugayenko
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use crate::Drain;
+use core::iter::FusedIterator;
+
+impl<'a, K, V> Drop for Drain<'a, K, V> {
+    fn drop(&mut self) {
+        for pair in &mut self.iter {
+            unsafe { pair.assume_init_drop() };
+        }
+    }
+}
+
+impl<'a, K: PartialEq, V> Iterator for Drain<'a, K, V> {
+    type Item = (K, V);
+
+    #[inline]
+    #[must_use]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|p| unsafe { p.assume_init_read() })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.iter.len(), Some(self.iter.len()))
+    }
+}
+
+impl<'a, K: PartialEq, V> ExactSizeIterator for Drain<'a, K, V> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
+impl<'a, K: PartialEq, V> FusedIterator for Drain<'a, K, V> {}

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,0 +1,128 @@
+// Copyright (c) 2024 Yegor Bugayenko
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use crate::{Entry, OccupiedEntry, VacantEntry};
+use core::mem;
+
+impl<'a, K: PartialEq, V, const N: usize> Entry<'a, K, V, N> {
+    pub fn or_insert(self, default: V) -> &'a mut V {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(default),
+        }
+    }
+
+    pub fn or_insert_with<F: FnOnce() -> V>(self, default: F) -> &'a mut V {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(default()),
+        }
+    }
+
+    pub fn or_insert_with_key<F: FnOnce(&K) -> V>(self, default: F) -> &'a mut V {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => {
+                let value = default(entry.key());
+                entry.insert(value)
+            }
+        }
+    }
+
+    pub fn key(&self) -> &K {
+        match self {
+            Entry::Occupied(entry) => entry.key(),
+            Entry::Vacant(entry) => entry.key(),
+        }
+    }
+
+    #[must_use]
+    pub fn and_modify<F>(self, f: F) -> Self
+    where
+        F: FnOnce(&mut V),
+    {
+        match self {
+            Entry::Occupied(mut entry) => {
+                f(entry.get_mut());
+                Entry::Occupied(entry)
+            }
+            Entry::Vacant(entry) => Entry::Vacant(entry),
+        }
+    }
+}
+
+impl<'a, K: PartialEq, V: Default, const N: usize> Entry<'a, K, V, N> {
+    pub fn or_default(self) -> &'a mut V {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(V::default()),
+        }
+    }
+}
+
+impl<'a, K: PartialEq, V, const N: usize> OccupiedEntry<'a, K, V, N> {
+    #[must_use]
+    pub fn key(&self) -> &K {
+        &self.table.item_ref(self.index).0
+    }
+
+    #[must_use]
+    pub fn remove_entry(self) -> (K, V) {
+        self.table.remove_index_read(self.index)
+    }
+
+    #[must_use]
+    pub fn get(&self) -> &V {
+        &self.table.item_ref(self.index).1
+    }
+
+    pub fn get_mut(&mut self) -> &mut V {
+        self.table.item_mut(self.index)
+    }
+
+    #[must_use]
+    pub fn into_mut(self) -> &'a mut V {
+        self.table.item_mut(self.index)
+    }
+
+    pub fn insert(&mut self, value: V) -> V {
+        mem::replace(self.get_mut(), value)
+    }
+
+    #[must_use]
+    pub fn remove(self) -> V {
+        self.table.remove_index_read(self.index).1
+    }
+}
+
+impl<'a, K: PartialEq, V, const N: usize> VacantEntry<'a, K, V, N> {
+    pub const fn key(&self) -> &K {
+        &self.key
+    }
+
+    pub fn into_key(self) -> K {
+        self.key
+    }
+
+    pub fn insert(self, value: V) -> &'a mut V {
+        let (index, _) = self.table.insert_i(self.key, value);
+        self.table.item_mut(index)
+    }
+}

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -48,6 +48,11 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
             (&p.0, &p.1)
         })
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 impl<'a, K, V> Iterator for IterMut<'a, K, V> {
@@ -59,6 +64,11 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
             let p = unsafe { p.assume_init_mut() };
             (&p.0, &mut p.1)
         })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
     }
 }
 
@@ -75,6 +85,11 @@ impl<K: PartialEq, V, const N: usize> Iterator for IntoIter<K, V, N> {
         } else {
             None
         }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.map.len - self.pos, Some(self.map.len - self.pos))
     }
 }
 

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -125,37 +125,6 @@ impl<K: PartialEq, V, const N: usize> Drop for IntoIter<K, V, N> {
     }
 }
 
-impl<'a, K, V> DoubleEndedIterator for Iter<'a, K, V> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(|p| {
-            let p = unsafe { p.assume_init_ref() };
-            (&p.0, &p.1)
-        })
-    }
-}
-
-impl<'a, K, V> DoubleEndedIterator for IterMut<'a, K, V> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(|p| {
-            let p = unsafe { p.assume_init_mut() };
-            (&p.0, &mut p.1)
-        })
-    }
-}
-
-impl<K: PartialEq, V, const N: usize> DoubleEndedIterator for IntoIter<K, V, N> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if self.pos < self.map.len {
-            self.map.len -= 1;
-            let i = self.map.len;
-            let p = self.map.item_read(i);
-            Some(p)
-        } else {
-            None
-        }
-    }
-}
-
 impl<'a, K, V> ExactSizeIterator for Iter<'a, K, V> {
     fn len(&self) -> usize {
         self.iter.len()

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -101,7 +101,7 @@ mod test {
         m.insert("bar".to_string(), 0);
         assert_eq!(
             m.into_keys().collect::<Vec<_>>(),
-            ["foo".to_string(), "bar".to_string()]
+            ["bar".to_string(), "foo".to_string()]
         );
     }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -44,6 +44,11 @@ impl<'a, K, V> Iterator for Keys<'a, K, V> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|p| p.0)
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 impl<K: PartialEq, V, const N: usize> Iterator for IntoKeys<K, V, N> {
@@ -52,6 +57,11 @@ impl<K: PartialEq, V, const N: usize> Iterator for IntoKeys<K, V, N> {
     #[inline]
     fn next(&mut self) -> Option<K> {
         self.iter.next().map(|p| p.0)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -55,18 +55,6 @@ impl<K: PartialEq, V, const N: usize> Iterator for IntoKeys<K, V, N> {
     }
 }
 
-impl<'a, K, V> DoubleEndedIterator for Keys<'a, K, V> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(|p| p.0)
-    }
-}
-
-impl<K: PartialEq, V, const N: usize> DoubleEndedIterator for IntoKeys<K, V, N> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(|p| p.0)
-    }
-}
-
 impl<'a, K, V> ExactSizeIterator for Keys<'a, K, V> {
     fn len(&self) -> usize {
         self.iter.len()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ mod clone;
 mod ctors;
 mod debug;
 mod display;
+mod drain;
 mod entry;
 mod eq;
 mod from;
@@ -66,7 +67,7 @@ mod serialization;
 mod set;
 mod values;
 
-pub use crate::set::{Set, SetIntoIter, SetIter};
+pub use crate::set::{Set, SetDrain, SetIntoIter, SetIter};
 use core::mem::MaybeUninit;
 
 /// A faster alternative of [`std::collections::HashMap`].
@@ -174,4 +175,11 @@ pub struct OccupiedEntry<'a, K: 'a + PartialEq, V: 'a, const N: usize> {
 pub struct VacantEntry<'a, K: 'a + PartialEq, V: 'a, const N: usize> {
     key: K,
     table: &'a mut Map<K, V, N>,
+}
+
+/// A draining iterator over the entries of a `Map`.
+///
+/// This struct is created by the drain method on `Map`. See its documentation for more.
+pub struct Drain<'a, K: 'a, V: 'a> {
+    iter: core::slice::IterMut<'a, MaybeUninit<(K, V)>>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ mod set;
 mod values;
 
 pub use crate::set::{Set, SetIntoIter, SetIter};
-use core::mem::{ManuallyDrop, MaybeUninit};
+use core::mem::MaybeUninit;
 
 /// A faster alternative of [`std::collections::HashMap`].
 ///
@@ -113,9 +113,9 @@ pub struct IterMut<'a, K, V> {
 }
 
 /// Into-iterator over the [`Map`].
+#[repr(transparent)]
 pub struct IntoIter<K: PartialEq, V, const N: usize> {
-    pos: usize,
-    map: ManuallyDrop<Map<K, V, N>>,
+    map: Map<K, V, N>,
 }
 
 /// An iterator over the values of the [`Map`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ mod clone;
 mod ctors;
 mod debug;
 mod display;
+mod entry;
 mod eq;
 mod from;
 mod index;
@@ -146,4 +147,31 @@ pub struct Keys<'a, K, V> {
 #[repr(transparent)]
 pub struct IntoKeys<K: PartialEq, V, const N: usize> {
     iter: IntoIter<K, V, N>,
+}
+
+/// A view into a single entry in a map, which may either be vacant or occupied.
+///
+/// This `enum` is constructed from the [`entry`] method on [`Map`].
+///
+/// [`entry`]: Map::entry
+pub enum Entry<'a, K: 'a + PartialEq, V: 'a, const N: usize> {
+    /// An occupied entry.
+    Occupied(OccupiedEntry<'a, K, V, N>),
+
+    /// A vacant entry.
+    Vacant(VacantEntry<'a, K, V, N>),
+}
+
+/// A view into an occupied entry in a `Map`.
+/// It is part of the [`Entry`] enum.
+pub struct OccupiedEntry<'a, K: 'a + PartialEq, V: 'a, const N: usize> {
+    index: usize,
+    table: &'a mut Map<K, V, N>,
+}
+
+/// A view into a vacant entry in a `Map`.
+/// It is part of the [`Entry`] enum.
+pub struct VacantEntry<'a, K: 'a + PartialEq, V: 'a, const N: usize> {
+    key: K,
+    table: &'a mut Map<K, V, N>,
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use crate::{Entry, Map, OccupiedEntry, VacantEntry};
+use crate::{Drain, Entry, Map, OccupiedEntry, VacantEntry};
 use core::borrow::Borrow;
 
 mod internal {
@@ -103,6 +103,17 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     #[must_use]
     pub const fn len(&self) -> usize {
         self.len
+    }
+
+    /// Clears the map, returning all key-value pairs as an iterator. Keeps the allocated memory for reuse.
+    ///
+    /// If the returned iterator is dropped before being fully consumed, it drops the remaining key-value pairs. The returned iterator keeps a mutable borrow on the map to optimize its implementation.
+    pub fn drain(&mut self) -> Drain<'_, K, V> {
+        let drain = Drain {
+            iter: self.pairs[0..self.len].iter_mut(),
+        };
+        self.len = 0;
+        drain
     }
 
     /// Does the map contain this key?

--- a/src/map.rs
+++ b/src/map.rs
@@ -123,17 +123,17 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
 
     /// Remove by key.
     #[inline]
-    pub fn remove<Q: PartialEq + ?Sized>(&mut self, k: &Q)
+    pub fn remove<Q: PartialEq + ?Sized>(&mut self, k: &Q) -> Option<V>
     where
         K: Borrow<Q>,
     {
         for i in 0..self.len {
             let p = self.item_ref(i);
             if p.0.borrow() == k {
-                self.remove_index_drop(i);
-                break;
+                return Some(self.remove_index_read(i).1);
             }
         }
+        None
     }
 
     /// Insert a single pair into the map.
@@ -145,9 +145,10 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     /// undefined behavior. This is done for the sake of performance, in order to
     /// avoid a repetitive check for the boundary condition on every `insert()`.
     #[inline]
-    pub fn insert(&mut self, k: K, v: V) {
+    pub fn insert(&mut self, k: K, v: V) -> Option<V> {
         let mut target = self.len;
         let mut i = 0;
+        let mut existing_value = None;
         loop {
             if i == self.len {
                 #[cfg(feature = "std")]
@@ -157,7 +158,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
             let p = self.item_ref(i);
             if p.0 == k {
                 target = i;
-                self.item_drop(i);
+                existing_value = Some(self.item_read(i).1);
                 break;
             }
             i += 1;
@@ -166,6 +167,8 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
         if target == self.len {
             self.len += 1;
         }
+
+        existing_value
     }
 
     /// Get a reference to a single value.
@@ -269,19 +272,19 @@ mod test {
     #[test]
     fn insert_and_check_length() {
         let mut m: Map<String, i32, 10> = Map::new();
-        m.insert("first".to_string(), 42);
+        assert_eq!(m.insert("first".to_string(), 42), None);
         assert_eq!(1, m.len());
-        m.insert("second".to_string(), 16);
+        assert_eq!(m.insert("second".to_string(), 16), None);
         assert_eq!(2, m.len());
-        m.insert("first".to_string(), 16);
+        assert_eq!(m.insert("first".to_string(), 16), Some(42));
         assert_eq!(2, m.len());
     }
 
     #[test]
     fn overwrites_keys() {
         let mut m: Map<i32, i32, 1> = Map::new();
-        m.insert(1, 42);
-        m.insert(1, 42);
+        assert_eq!(m.insert(1, 42), None);
+        assert_eq!(m.insert(1, 42), Some(42));
         assert_eq!(1, m.len());
     }
 
@@ -290,7 +293,7 @@ mod test {
     #[cfg(debug_assertions)]
     fn cant_write_into_empty_map() {
         let mut m: Map<i32, i32, 0> = Map::new();
-        m.insert(1, 42);
+        assert_eq!(m.insert(1, 42), None);
     }
 
     #[test]
@@ -303,22 +306,22 @@ mod test {
     fn is_empty_check() {
         let mut m: Map<u32, u32, 10> = Map::new();
         assert!(m.is_empty());
-        m.insert(42, 42);
+        assert_eq!(m.insert(42, 42), None);
         assert!(!m.is_empty());
     }
 
     #[test]
     fn insert_and_gets() {
         let mut m: Map<String, i32, 10> = Map::new();
-        m.insert("one".to_string(), 42);
-        m.insert("two".to_string(), 16);
+        assert_eq!(m.insert("one".to_string(), 42), None);
+        assert_eq!(m.insert("two".to_string(), 16), None);
         assert_eq!(16, *m.get("two").unwrap());
     }
 
     #[test]
     fn insert_and_gets_mut() {
         let mut m: Map<i32, [i32; 3], 10> = Map::new();
-        m.insert(42, [1, 2, 3]);
+        assert_eq!(m.insert(42, [1, 2, 3]), None);
         let a = m.get_mut(&42).unwrap();
         a[0] = 500;
         assert_eq!(500, m.get(&42).unwrap()[0]);
@@ -327,7 +330,7 @@ mod test {
     #[test]
     fn checks_key() {
         let mut m: Map<String, i32, 10> = Map::new();
-        m.insert("one".to_string(), 42);
+        assert_eq!(m.insert("one".to_string(), 42), None);
         assert!(m.contains_key("one"));
         assert!(!m.contains_key("another"));
     }
@@ -335,28 +338,28 @@ mod test {
     #[test]
     fn gets_missing_key() {
         let mut m: Map<String, i32, 10> = Map::new();
-        m.insert("one".to_string(), 42);
+        assert_eq!(m.insert("one".to_string(), 42), None);
         assert!(m.get("two").is_none());
     }
 
     #[test]
     fn mut_gets_missing_key() {
         let mut m: Map<String, i32, 10> = Map::new();
-        m.insert("one".to_string(), 42);
+        assert_eq!(m.insert("one".to_string(), 42), None);
         assert!(m.get_mut("two").is_none());
     }
 
     #[test]
     fn removes_simple_pair() {
         let mut m: Map<String, i32, 10> = Map::new();
-        m.insert("one".to_string(), 42);
-        m.remove("one");
-        m.remove("another");
+        assert_eq!(m.insert("one".to_string(), 42), None);
+        assert_eq!(m.remove("one"), Some(42));
+        assert_eq!(m.remove("another"), None);
         assert!(m.get("one").is_none());
     }
 
     #[cfg(test)]
-    #[derive(Clone)]
+    #[derive(Clone, PartialEq, Debug)]
     struct Foo {
         v: [u32; 3],
     }
@@ -365,12 +368,12 @@ mod test {
     fn insert_struct() {
         let mut m: Map<u8, Foo, 8> = Map::new();
         let foo = Foo { v: [1, 2, 100] };
-        m.insert(1, foo);
+        assert_eq!(m.insert(1, foo), None);
         assert_eq!(100, m.into_iter().next().unwrap().1.v[2]);
     }
 
     #[cfg(test)]
-    #[derive(Clone)]
+    #[derive(Clone, PartialEq, Debug)]
     struct Composite {
         r: Map<u8, u8, 1>,
     }
@@ -379,7 +382,7 @@ mod test {
     fn insert_composite() {
         let mut m: Map<u8, Composite, 8> = Map::new();
         let c = Composite { r: Map::new() };
-        m.insert(1, c);
+        assert_eq!(m.insert(1, c), None);
         assert_eq!(0, m.into_iter().next().unwrap().1.r.len());
     }
 
@@ -392,7 +395,7 @@ mod test {
     #[test]
     fn clears_it_up() {
         let mut m: Map<String, i32, 10> = Map::new();
-        m.insert("one".to_string(), 42);
+        assert_eq!(m.insert("one".to_string(), 42), None);
         m.clear();
         assert_eq!(0, m.len());
     }
@@ -414,8 +417,8 @@ mod test {
         for _ in 0..2 {
             let cap = m.capacity();
             for i in 0..cap {
-                m.insert(i, 256);
-                m.remove(&i);
+                assert_eq!(m.insert(i, 256), None);
+                assert_eq!(m.remove(&i), Some(256));
             }
         }
     }
@@ -424,7 +427,7 @@ mod test {
     fn get_key_value() {
         let mut m: Map<String, i32, 10> = Map::new();
         let k = "key".to_string();
-        m.insert(k.clone(), 42);
+        assert_eq!(m.insert(k.clone(), 42), None);
         assert_eq!(m.get_key_value(&k), Some((&k, &42)));
         assert!(m.contains_key(&k));
     }
@@ -432,7 +435,7 @@ mod test {
     #[test]
     fn get_absent_key_value() {
         let mut m: Map<String, i32, 10> = Map::new();
-        m.insert("one".to_string(), 42);
+        assert_eq!(m.insert("one".to_string(), 42), None);
         assert_eq!(m.get_key_value("two"), None);
     }
 
@@ -440,7 +443,7 @@ mod test {
     fn remove_entry_present() {
         let mut m: Map<String, i32, 10> = Map::new();
         let k = "key".to_string();
-        m.insert(k.clone(), 42);
+        assert_eq!(m.insert(k.clone(), 42), None);
         assert_eq!(m.remove_entry(&k), Some((k.clone(), 42)));
         assert!(!m.contains_key(&k));
     }
@@ -448,7 +451,7 @@ mod test {
     #[test]
     fn remove_entry_absent() {
         let mut m: Map<String, i32, 10> = Map::new();
-        m.insert("one".to_string(), 42);
+        assert_eq!(m.insert("one".to_string(), 42), None);
         assert_eq!(m.remove_entry("two"), None);
     }
 
@@ -457,18 +460,18 @@ mod test {
         use std::rc::Rc;
         let mut m: Map<(), Rc<()>, 8> = Map::new();
         let v = Rc::new(());
-        m.insert((), Rc::clone(&v));
+        assert_eq!(m.insert((), Rc::clone(&v)), None);
         assert_eq!(Rc::strong_count(&v), 2);
-        m.remove_entry(&());
+        assert_eq!(m.remove_entry(&()), Some(((), Rc::clone(&v))));
         assert_eq!(Rc::strong_count(&v), 1);
     }
 
     #[test]
     fn insert_after_remove() {
         let mut m: Map<_, _, 1> = Map::new();
-        m.insert(1, 2);
-        m.remove(&1);
-        m.insert(1, 3);
+        assert_eq!(m.insert(1, 2), None);
+        assert_eq!(m.remove(&1), Some(2));
+        assert_eq!(m.insert(1, 3), None);
     }
 
     #[test]
@@ -476,19 +479,19 @@ mod test {
         use std::rc::Rc;
         let mut m: Map<_, _, 1> = Map::new();
         let v = Rc::new(());
-        m.insert((), Rc::clone(&v));
+        assert_eq!(m.insert((), Rc::clone(&v)), None);
         assert_eq!(Rc::strong_count(&v), 2);
-        m.insert((), Rc::clone(&v));
+        assert_eq!(m.insert((), Rc::clone(&v)), Some(Rc::clone(&v)));
         assert_eq!(Rc::strong_count(&v), 2);
     }
 
     #[test]
     fn insert_duplicate_after_remove() {
         let mut m: Map<_, _, 2> = Map::new();
-        m.insert(1, 1);
-        m.insert(2, 2);
-        m.remove(&1);
-        m.insert(2, 3);
+        assert_eq!(m.insert(1, 1), None);
+        assert_eq!(m.insert(2, 2), None);
+        assert_eq!(m.remove(&1), Some(1));
+        assert_eq!(m.insert(2, 3), Some(2));
         assert_eq!(1, m.len());
         assert_eq!(3, m[&2]);
     }

--- a/src/set/drain.rs
+++ b/src/set/drain.rs
@@ -1,0 +1,46 @@
+// Copyright (c) 2024 Yegor Bugayenko
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use crate::SetDrain;
+use core::iter::FusedIterator;
+
+impl<'a, K: PartialEq> Iterator for SetDrain<'a, K> {
+    type Item = K;
+
+    #[inline]
+    #[must_use]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|(k, ())| k)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.iter.len(), Some(self.iter.len()))
+    }
+}
+
+impl<'a, K: PartialEq> ExactSizeIterator for SetDrain<'a, K> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
+impl<'a, K: PartialEq> FusedIterator for SetDrain<'a, K> {}

--- a/src/set/functions.rs
+++ b/src/set/functions.rs
@@ -53,16 +53,21 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
         self.map.contains_key(k)
     }
 
-    /// Remove by key.
+    /// Removes a value from the set. Returns whether the value was present in the set.
     #[inline]
-    pub fn remove<Q: PartialEq + ?Sized>(&mut self, k: &Q)
+    pub fn remove<Q: PartialEq + ?Sized>(&mut self, k: &Q) -> bool
     where
         T: Borrow<Q>,
     {
-        self.map.remove(k);
+        self.map.remove(k).is_some()
     }
 
-    /// Insert a single pair into the set.
+    /// Adds a value to the set.
+    ///
+    /// Returns whether the value was newly inserted. That is:
+    ///
+    /// If the set did not previously contain this value, true is returned.
+    /// If the set already contained this value, false is returned, and the set is not modified: original value is not replaced, and the value passed as argument is dropped.
     ///
     /// # Panics
     ///
@@ -71,8 +76,8 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
     /// undefined behavior. This is done for the sake of performance, in order to
     /// avoid a repetitive check for the boundary condition on every `insert()`.
     #[inline]
-    pub fn insert(&mut self, k: T) {
-        self.map.insert(k, ());
+    pub fn insert(&mut self, k: T) -> bool {
+        self.map.insert(k, ()).is_none()
     }
 
     /// Get a reference to a single value.

--- a/src/set/functions.rs
+++ b/src/set/functions.rs
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use crate::Set;
+use crate::{Set, SetDrain};
 use core::borrow::Borrow;
 
 impl<T: PartialEq, const N: usize> Set<T, N> {
@@ -41,6 +41,15 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
     #[must_use]
     pub const fn len(&self) -> usize {
         self.map.len()
+    }
+
+    /// Clears the set, returning all elements as an iterator. Keeps the allocated memory for reuse.
+    ///
+    /// If the returned iterator is dropped before being fully consumed, it drops the remaining elements. The returned iterator keeps a mutable borrow on the set to optimize its implementation.
+    pub fn drain(&mut self) -> SetDrain<'_, T> {
+        SetDrain {
+            iter: self.map.drain(),
+        }
     }
 
     /// Does the set contain this key?

--- a/src/set/iterators.rs
+++ b/src/set/iterators.rs
@@ -40,6 +40,11 @@ impl<'a, T> Iterator for SetIter<'a, T> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 impl<T: PartialEq, const N: usize> Iterator for SetIntoIter<T, N> {
@@ -49,6 +54,11 @@ impl<T: PartialEq, const N: usize> Iterator for SetIntoIter<T, N> {
     #[must_use]
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
     }
 }
 

--- a/src/set/iterators.rs
+++ b/src/set/iterators.rs
@@ -76,18 +76,6 @@ impl<T: PartialEq, const N: usize> IntoIterator for Set<T, N> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator for SetIter<'a, T> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back()
-    }
-}
-
-impl<T: PartialEq, const N: usize> DoubleEndedIterator for SetIntoIter<T, N> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back()
-    }
-}
-
 impl<'a, T> ExactSizeIterator for SetIter<'a, T> {
     fn len(&self) -> usize {
         self.iter.len()

--- a/src/set/mod.rs
+++ b/src/set/mod.rs
@@ -2,6 +2,7 @@ mod clone;
 mod ctors;
 mod debug;
 mod display;
+mod drain;
 mod eq;
 mod from;
 mod functions;
@@ -53,4 +54,10 @@ pub struct SetIter<'a, T> {
 #[allow(clippy::module_name_repetitions)]
 pub struct SetIntoIter<T: PartialEq, const N: usize> {
     iter: crate::IntoKeys<T, (), N>,
+}
+
+#[repr(transparent)]
+#[allow(clippy::module_name_repetitions)]
+pub struct SetDrain<'a, T: PartialEq> {
+    iter: crate::Drain<'a, T, ()>,
 }

--- a/src/values.rs
+++ b/src/values.rs
@@ -72,24 +72,6 @@ impl<K: PartialEq, V, const N: usize> Iterator for IntoValues<K, V, N> {
     }
 }
 
-impl<'a, K, V> DoubleEndedIterator for Values<'a, K, V> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(|p| p.1)
-    }
-}
-
-impl<'a, K, V> DoubleEndedIterator for ValuesMut<'a, K, V> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(|p| p.1)
-    }
-}
-
-impl<K: PartialEq, V, const N: usize> DoubleEndedIterator for IntoValues<K, V, N> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(|p| p.1)
-    }
-}
-
 impl<'a, K, V> ExactSizeIterator for Values<'a, K, V> {
     fn len(&self) -> usize {
         self.iter.len()

--- a/src/values.rs
+++ b/src/values.rs
@@ -52,6 +52,11 @@ impl<'a, K, V> Iterator for Values<'a, K, V> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|p| p.1)
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
@@ -61,6 +66,11 @@ impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|p| p.1)
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 impl<K: PartialEq, V, const N: usize> Iterator for IntoValues<K, V, N> {
@@ -69,6 +79,11 @@ impl<K: PartialEq, V, const N: usize> Iterator for IntoValues<K, V, N> {
     #[inline]
     fn next(&mut self) -> Option<V> {
         self.iter.next().map(|p| p.1)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
     }
 }
 


### PR DESCRIPTION
This fixes a issue and several improvements.

* Remove DoubleEndedIterator

  There are not available at HashMap/Set either and are not very
  helpful since they are not ordered anyway.
* Fix ExactSizeIterator

  The implementation requires a valid size_hint, which is now given.
* Optimize IntoIter
* Change insert and remove to behave like HashMap/Set
* Entry
* Drain

With this (almost) all issues should been done, I hope.
Feel free to remove commits you don't see fit.