### PR TITLE
Added linter for Github Actions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,21 @@
+---
+name: actionlint
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  actionlint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 bin/
 *.bak
 tmp/
+.DS_Store


### PR DESCRIPTION
@yegor256 
This repository contains many different GitHub actions in its composition. In order to prevent errors when changing them in the future or adding new actions, I suggest adding a linter. This will help to improve the quality of the code and the development experience in the project.