### PR TITLE
Change contains_key for a more idiomatic Rust code

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -106,13 +106,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     where
         K: Borrow<Q>,
     {
-        for i in 0..self.len {
-            let p = self.item_ref(i);
-            if p.0.borrow() == k {
-                return true;
-            }
-        }
-        false
+        self.iter().any(|(x, _)| x.borrow() == k)
     }
 
     /// Remove by key.


### PR DESCRIPTION
A prettier and more idiomatic way for Rust. Compiler Explorer shows even less assembler, you can check: https://godbolt.org/z/Ts4K8bqdE