### PR TITLE
Completely implement the rest std methods about the Linear `Set` data structure.

### DIFF
--- a/src/eq.rs
+++ b/src/eq.rs
@@ -3,28 +3,30 @@
 
 use crate::Map;
 
-impl<K: PartialEq, V: PartialEq, const N: usize> PartialEq for Map<K, V, N> {
-    /// Two maps can be compared.
+impl<K: PartialEq, V: PartialEq, const N: usize, const M: usize> PartialEq<Map<K, V, M>>
+    for Map<K, V, N>
+{
+    /// Two maps can be compared. (The capacity does not affect comparison.)
     ///
     /// For example:
     ///
     /// ```
-    /// let mut m1: micromap::Map<u8, i32, 10> = micromap::Map::new();
+    /// let mut m1: micromap::Map<u8, i32, 5> = micromap::Map::new();
     /// let mut m2: micromap::Map<u8, i32, 10> = micromap::Map::new();
     /// m1.insert(1, 42);
     /// m2.insert(1, 42);
-    /// # #[cfg(std)]
+    ///
     /// assert_eq!(m1, m2);
     /// // two maps with different order of key-value pairs are still equal:
     /// m1.insert(2, 1);
     /// m1.insert(3, 16);
     /// m2.insert(3, 16);
     /// m2.insert(2, 1);
-    /// # #[cfg(std)]
+    ///
     /// assert_eq!(m1, m2);
     /// ```
     #[inline]
-    fn eq(&self, other: &Self) -> bool {
+    fn eq(&self, other: &Map<K, V, M>) -> bool {
         self.len() == other.len() && self.iter().all(|(k, v)| other.get(k) == Some(v))
     }
 }
@@ -38,10 +40,20 @@ mod tests {
 
     #[test]
     fn compares_two_maps() {
-        let mut m1: Map<String, i32, 10> = Map::new();
+        let mut m1: Map<String, i32, 5> = Map::new();
         m1.insert("first".to_string(), 42);
-        let mut m2: Map<String, i32, 10> = Map::new();
+        let mut m2: Map<String, i32, 5> = Map::new();
         m2.insert("first".to_string(), 42);
         assert!(m1.eq(&m2));
+    }
+
+    #[test]
+    fn compares_two_diff_cap_maps() {
+        let mut m1: Map<char, i32, 3> = Map::from([('a', 97), ('b', 98), ('c', 99)]);
+        let mut m2: Map<char, i32, 4> = Map::from([('c', 99), ('c', 99), ('c', 99), ('b', 98)]);
+        m2.insert('a', 97);
+        assert!(m1.eq(&m2));
+        m1.remove(&'c');
+        assert!(m1.ne(&m2));
     }
 }

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -43,6 +43,11 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.iter.len()
+    }
 }
 
 impl<'a, K, V> Iterator for IterMut<'a, K, V> {
@@ -59,6 +64,11 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.iter.len()
     }
 }
 
@@ -78,6 +88,11 @@ impl<K: PartialEq, V, const N: usize> Iterator for IntoIter<K, V, N> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.map.len, Some(self.map.len))
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.map.len()
     }
 }
 

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -19,6 +19,15 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     }
 }
 
+impl<K, V> Clone for Iter<'_, K, V> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            iter: self.iter.clone(),
+        }
+    }
+}
+
 impl<'a, K, V> Iterator for Iter<'a, K, V> {
     type Item = (&'a K, &'a V);
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -20,6 +20,15 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     }
 }
 
+impl<K, V> Clone for Keys<'_, K, V> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Keys {
+            iter: self.iter.clone(),
+        }
+    }
+}
+
 impl<'a, K, V> Iterator for Keys<'a, K, V> {
     type Item = &'a K;
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -134,25 +134,24 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     /// avoid a repetitive check for the boundary condition on every `insert()`.
     #[inline]
     pub fn insert(&mut self, k: K, v: V) -> Option<V> {
-        let (_, existing_value) = self.insert_i(k, v);
-        existing_value
+        let (_, existing_pair) = self.insert_i(k, v);
+        existing_pair.map(|(_, v)| v)
     }
 
     #[inline]
-    pub(crate) fn insert_i(&mut self, k: K, v: V) -> (usize, Option<V>) {
+    pub(crate) fn insert_i(&mut self, k: K, v: V) -> (usize, Option<(K, V)>) {
         let mut target = self.len;
         let mut i = 0;
-        let mut existing_value = None;
+        let mut existing_pair = None;
         loop {
             if i == self.len {
-                #[cfg(feature = "std")]
-                debug_assert!(target < N, "No more keys available in the map");
+                core::debug_assert!(target < N, "No more keys available in the map");
                 break;
             }
             let p = self.item_ref(i);
             if p.0 == k {
                 target = i;
-                existing_value = Some(self.item_read(i).1);
+                existing_pair = Some(self.item_read(i));
                 break;
             }
             i += 1;
@@ -162,7 +161,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
             self.len += 1;
         }
 
-        (target, existing_value)
+        (target, existing_pair)
     }
 
     /// Get a reference to a single value.

--- a/src/map.rs
+++ b/src/map.rs
@@ -145,7 +145,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
         let mut existing_pair = None;
         loop {
             if i == self.len {
-                core::debug_assert!(target < N, "No more keys available in the map");
+                core::debug_assert!(target < N, "No more key-value slot available in the map");
                 break;
             }
             let p = self.item_ref(i);

--- a/src/set/difference.rs
+++ b/src/set/difference.rs
@@ -103,9 +103,8 @@ impl<'a, T: PartialEq, const M: usize> Iterator for Difference<'a, T, M> {
     }
 }
 
-#[cfg(feature = "std")]
-impl<T: std::fmt::Debug + PartialEq, const M: usize> std::fmt::Debug for Difference<'_, T, M> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T: core::fmt::Debug + PartialEq, const M: usize> core::fmt::Debug for Difference<'_, T, M> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
 }

--- a/src/set/difference.rs
+++ b/src/set/difference.rs
@@ -13,7 +13,7 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
     ///
     /// ```
     /// use micromap::Set;
-    /// 
+    ///
     /// let a = Set::from([1, 2, 3]);
     /// let b = Set::from([4, 2, 3, 4]);
     ///
@@ -22,13 +22,13 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
     ///     println!("{x}"); // Print 1
     /// }
     ///
-    /// let diff: Set<_, 3> = a.difference(&b).collect();
-    /// assert_eq!(diff, [1].iter().collect());
+    /// let diff: Set<_, 3> = a.difference(&b).copied().collect();
+    /// assert_eq!(diff, Set::from([1]));
     ///
     /// // Note that difference is not symmetric,
     /// // and `b - a` means something else:
-    /// let diff: Set<_, 4> = b.difference(&a).collect();
-    /// assert_eq!(diff, [4].iter().collect());
+    /// let diff: Set<_, 4> = b.difference(&a).copied().collect();
+    /// assert_eq!(diff, Set::from([4]));
     /// ```
     #[inline]
     pub fn difference<'a, const M: usize>(&'a self, other: &'a Set<T, M>) -> Difference<'a, T, M> {
@@ -138,13 +138,13 @@ mod tests {
     //     };
     //
     //     assert_eq!(
-    //         Set::<_>::from_iter(first_only.into_iter().copied()),
-    //         Set::<_>::from_iter(["love", "surf"])
+    //         Set::<_>::from(first_only.into_iter().copied()),
+    //         Set::<_>::from(["love", "surf"])
     //     );
     // }
 
     #[test]
-    fn test_difference() {
+    fn difference_disjoint() {
         let set_a: Set<u32, 5> = Set::from([0, 1, 3, 5, 7]);
         let set_b: Set<u32, 4> = Set::from([2, 4, 6, 8]);
 
@@ -153,51 +153,51 @@ mod tests {
     }
 
     #[test]
-    fn test_difference_with_overlap() {
-        let set_a: Set<u32, 4> = Set::from([1, 3, 5, 7]);
-        let set_b: Set<u32, 5> = Set::from([3, 5, 6, 8, 9]);
+    fn difference_with_overlap() {
+        let set_a = Set::from([1, 3, 5, 7]);
+        let set_b = Set::from([3, 5, 6, 8, 9]);
 
         let set_diff = set_a.difference(&set_b).copied().collect::<Set<u32, 4>>();
-        let expected: Set<u32, 4> = Set::from_iter([1, 7]);
+        let expected = Set::from([1, 7]);
         assert_eq!(expected, set_diff);
     }
 
     #[test]
-    fn test_difference_complete_overlap() {
-        let set_a: Set<u32, 4> = Set::from([1, 3, 5, 7]);
-        let set_b: Set<u32, 4> = Set::from([1, 3, 5, 7]);
+    fn difference_complete_overlap() {
+        let set_a = Set::from([1, 3, 5, 7]);
+        let set_b = Set::from([1, 3, 5, 7]);
 
         let set_diff = set_a.difference(&set_b).copied().collect::<Set<u32, 4>>();
-        let expected: Set<u32, 4> = Set::from_iter([]);
+        let expected = Set::from([]);
         assert_eq!(expected, set_diff);
     }
 
     #[test]
-    fn test_difference_empty_set() {
-        let set_a: Set<u32, 4> = Set::from([1, 3, 5, 7]);
-        let set_b: Set<u32, 4> = Set::from_iter([]);
+    fn difference_empty_set() {
+        let set_a = Set::from([1, 3, 5, 7]);
+        let set_b = Set::from([]);
 
         let set_diff = set_a.difference(&set_b).copied().collect::<Set<u32, 4>>();
         assert_eq!(set_a, set_diff);
     }
 
     #[test]
-    fn test_difference_with_empty_first_set() {
-        let set_a: Set<u32, 4> = Set::from_iter([]);
-        let set_b: Set<u32, 4> = Set::from([2, 4, 6, 8]);
+    fn difference_with_empty_first_set() {
+        let set_a = Set::from([]);
+        let set_b = Set::from([2, 4, 6, 8]);
 
         let set_diff = set_a.difference(&set_b).copied().collect::<Set<u32, 4>>();
-        let expected: Set<u32, 4> = Set::from_iter([]);
+        let expected = Set::from([]);
         assert_eq!(expected, set_diff);
     }
 
     #[test]
-    fn test_difference_partial_overlap() {
+    fn difference_partial_overlap() {
         let set_a = Set::from([1, 2, 3, 4, 5, 6]);
         let set_b = Set::from([4, 5, 6, 7, 8, 9]);
 
         let set_diff = set_a.difference(&set_b).copied().collect::<Set<_, 6>>();
-        let expected = Set::from_iter([1, 2, 3]);
+        let expected = Set::from([1, 2, 3]);
         assert_eq!(expected, set_diff);
     }
 }

--- a/src/set/difference.rs
+++ b/src/set/difference.rs
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023-2025 Yegor Bugayenko
+// SPDX-FileCopyrightText: Copyright (c) 2025 owtotwo
+// SPDX-License-Identifier: MIT
+
+use crate::Set;
+use crate::SetIter;
+
+impl<T: PartialEq, const N: usize> Set<T, N> {
+    /// Visits the values representing the difference,
+    /// i.e., the values that are in `self` but not in `other`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let a = Set::from([1, 2, 3]);
+    /// let b = Set::from([4, 2, 3, 4]);
+    ///
+    /// // Can be seen as `a - b`.
+    /// for x in a.difference(&b) {
+    ///     println!("{x}"); // Print 1
+    /// }
+    ///
+    /// let diff: Set<_, 3> = a.difference(&b).collect();
+    /// assert_eq!(diff, [1].iter().collect());
+    ///
+    /// // Note that difference is not symmetric,
+    /// // and `b - a` means something else:
+    /// let diff: Set<_, 4> = b.difference(&a).collect();
+    /// assert_eq!(diff, [4].iter().collect());
+    /// ```
+    #[inline]
+    pub fn difference<'a, const M: usize>(&'a self, other: &'a Set<T, M>) -> Difference<'a, T, M> {
+        Difference {
+            iter: self.iter(),
+            other,
+        }
+    }
+}
+
+/// A lazy iterator producing elements in the difference of Linear `Set`s.
+///
+/// This `struct` is created by the [`difference`] method on [`Set`].
+///
+/// [`difference`]: Set::difference
+///
+/// # Examples
+///
+/// ```
+/// use micromap::Set;
+///
+/// let a = Set::from([1, 2, 3]);
+/// let b = Set::from([4, 2, 3, 4]);
+///
+/// let mut difference = a.difference(&b);
+/// ```
+pub struct Difference<'a, T: 'a + PartialEq, const M: usize> {
+    // iterator of the first set
+    iter: SetIter<'a, T>,
+    // the second set
+    other: &'a Set<T, M>,
+}
+
+impl<T: PartialEq, const M: usize> Clone for Difference<'_, T, M> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Difference {
+            iter: self.iter.clone(),
+            ..*self
+        }
+    }
+}
+
+impl<'a, T: PartialEq, const M: usize> Iterator for Difference<'a, T, M> {
+    type Item = &'a T;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.by_ref().find(|&item| !self.other.contains(item))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.iter.size_hint();
+        (0, upper)
+    }
+
+    #[inline]
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        // Maybe using iterator is better than the default Iterator::fold() which uses while loop.
+        self.iter.fold(init, |acc, elt| {
+            if self.other.contains(elt) {
+                acc
+            } else {
+                f(acc, elt)
+            }
+        })
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T: std::fmt::Debug + PartialEq, const M: usize> std::fmt::Debug for Difference<'_, T, M> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::Set;
+
+    // TODO: This is a BUG in the standard library function.
+    // #[test]
+    // #[ignore]
+    // fn difference_lifetime() {
+    //     use std::collections::hash_set::HashSet as Set;
+    // 
+    //     let sentence_1 = String::from("I love the surf and the sand.");
+    //     let sentence_1_words: Set<&str> = sentence_1.split(" ").collect();
+    // 
+    //     let first_only = {
+    //         let sentence_2 = String::from("I hate the hate and the sand.");
+    //         let sentence_2_words: Set<&str> = sentence_2.split(" ").collect();
+    //         let first_only: Vec<_> = sentence_1_words.difference(&sentence_2_words).collect();
+    //         let second_only: Vec<_> = sentence_2_words.difference(&sentence_1_words).collect();
+    // 
+    //         println!("First  Sentence: {}", sentence_1);
+    //         println!("Second Sentence: {}", sentence_2);
+    //         println!("{:?}", first_only);
+    //         println!("{:?}", second_only);
+    //         first_only
+    //     };
+    // 
+    //     assert_eq!(
+    //         Set::<_>::from_iter(first_only.into_iter().copied()),
+    //         Set::<_>::from_iter(["love", "surf"])
+    //     );
+    // }
+
+    #[test]
+    fn test_difference() {
+        let set_a: Set<u32, 5> = Set::from([0, 1, 3, 5, 7]);
+        let set_b: Set<u32, 4> = Set::from([2, 4, 6, 8]);
+
+        let set_diff = set_a.difference(&set_b).copied().collect::<Set<u32, 5>>();
+        assert_eq!(set_a, set_diff);
+    }
+
+    #[test]
+    fn test_difference_with_overlap() {
+        let set_a: Set<u32, 4> = Set::from([1, 3, 5, 7]);
+        let set_b: Set<u32, 5> = Set::from([3, 5, 6, 8, 9]);
+
+        let set_diff = set_a.difference(&set_b).copied().collect::<Set<u32, 4>>();
+        let expected: Set<u32, 4> = Set::from_iter([1, 7]);
+        assert_eq!(expected, set_diff);
+    }
+
+    #[test]
+    fn test_difference_complete_overlap() {
+        let set_a: Set<u32, 4> = Set::from([1, 3, 5, 7]);
+        let set_b: Set<u32, 4> = Set::from([1, 3, 5, 7]);
+
+        let set_diff = set_a.difference(&set_b).copied().collect::<Set<u32, 4>>();
+        let expected: Set<u32, 4> = Set::from_iter([]);
+        assert_eq!(expected, set_diff);
+    }
+
+    #[test]
+    fn test_difference_empty_set() {
+        let set_a: Set<u32, 4> = Set::from([1, 3, 5, 7]);
+        let set_b: Set<u32, 4> = Set::from_iter([]);
+
+        let set_diff = set_a.difference(&set_b).copied().collect::<Set<u32, 4>>();
+        assert_eq!(set_a, set_diff);
+    }
+
+    #[test]
+    fn test_difference_with_empty_first_set() {
+        let set_a: Set<u32, 4> = Set::from_iter([]);
+        let set_b: Set<u32, 4> = Set::from([2, 4, 6, 8]);
+
+        let set_diff = set_a.difference(&set_b).copied().collect::<Set<u32, 4>>();
+        let expected: Set<u32, 4> = Set::from_iter([]);
+        assert_eq!(expected, set_diff);
+    }
+
+    #[test]
+    fn test_difference_partial_overlap() {
+        let set_a = Set::from([1, 2, 3, 4, 5, 6]);
+        let set_b = Set::from([4, 5, 6, 7, 8, 9]);
+
+        let set_diff = set_a.difference(&set_b).copied().collect::<Set<_, 6>>();
+        let expected = Set::from_iter([1, 2, 3]);
+        assert_eq!(expected, set_diff);
+    }
+}

--- a/src/set/difference.rs
+++ b/src/set/difference.rs
@@ -12,6 +12,8 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
     /// # Examples
     ///
     /// ```
+    /// use micromap::Set;
+    /// 
     /// let a = Set::from([1, 2, 3]);
     /// let b = Set::from([4, 2, 3, 4]);
     ///
@@ -113,28 +115,28 @@ mod tests {
 
     use crate::Set;
 
-    // TODO: This is a BUG in the standard library function.
+    // NOTE: This is a BUG in the standard library function.
     // #[test]
     // #[ignore]
     // fn difference_lifetime() {
     //     use std::collections::hash_set::HashSet as Set;
-    // 
+    //
     //     let sentence_1 = String::from("I love the surf and the sand.");
     //     let sentence_1_words: Set<&str> = sentence_1.split(" ").collect();
-    // 
+    //
     //     let first_only = {
     //         let sentence_2 = String::from("I hate the hate and the sand.");
     //         let sentence_2_words: Set<&str> = sentence_2.split(" ").collect();
     //         let first_only: Vec<_> = sentence_1_words.difference(&sentence_2_words).collect();
     //         let second_only: Vec<_> = sentence_2_words.difference(&sentence_1_words).collect();
-    // 
+    //
     //         println!("First  Sentence: {}", sentence_1);
     //         println!("Second Sentence: {}", sentence_2);
     //         println!("{:?}", first_only);
     //         println!("{:?}", second_only);
     //         first_only
     //     };
-    // 
+    //
     //     assert_eq!(
     //         Set::<_>::from_iter(first_only.into_iter().copied()),
     //         Set::<_>::from_iter(["love", "surf"])

--- a/src/set/eq.rs
+++ b/src/set/eq.rs
@@ -1,32 +1,99 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023-2025 Yegor Bugayenko
+// SPDX-FileCopyrightText: Copyright (c) 2025 owtotwo
 // SPDX-License-Identifier: MIT
 
 use crate::Set;
 
-impl<T: PartialEq, const N: usize> PartialEq for Set<T, N> {
-    /// Two sets can be compared.
+impl<T: PartialEq, const N: usize, const M: usize> PartialEq<Set<T, M>> for Set<T, N> {
+    /// Two sets can be compared. (The capacity does not affect comparison.)
     ///
     /// For example:
     ///
     /// ```
-    /// let mut m1: micromap::Set<u8, 10> = micromap::Set::new();
-    /// let mut m2: micromap::Set<u8, 10> = micromap::Set::new();
+    /// let mut m1: micromap::Set<_, 5> = micromap::Set::new();
+    /// let mut m2: micromap::Set<_, 10> = micromap::Set::new();
     /// m1.insert(1);
     /// m2.insert(1);
-    /// # #[cfg(std)]
+    ///
     /// assert_eq!(m1, m2);
     /// // two sets with different order of key-value pairs are still equal:
     /// m1.insert(2);
     /// m1.insert(3);
     /// m2.insert(3);
     /// m2.insert(2);
-    /// # #[cfg(std)]
+    ///
     /// assert_eq!(m1, m2);
     /// ```
     #[inline]
-    fn eq(&self, other: &Self) -> bool {
+    fn eq(&self, other: &Set<T, M>) -> bool {
         self.map.eq(&other.map)
     }
 }
 
 impl<T: Eq, const N: usize> Eq for Set<T, N> {}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn compares_two_sets() {
+        let mut s1: Set<i32, 1> = Set::new();
+        s1.insert(1);
+        let mut s2: Set<i32, 1> = Set::new();
+        s2.insert(1);
+        assert_eq!(s1, s2);
+    }
+
+    #[test]
+    fn compares_sets_with_different_order() {
+        let mut s1: Set<i32, 3> = Set::new();
+        s1.insert(1);
+        s1.insert(2);
+        s1.insert(3);
+
+        let mut s2: Set<i32, 3> = Set::new();
+        s2.insert(3);
+        s2.insert(2);
+        s2.insert(1);
+
+        assert_eq!(s1, s2);
+    }
+
+    #[test]
+    fn compares_sets_with_different_lengths() {
+        let mut s1: Set<i32, 3> = Set::new();
+        s1.insert(1);
+        s1.insert(2);
+
+        let mut s2: Set<i32, 3> = Set::new();
+        s2.insert(1);
+
+        assert_ne!(s1, s2);
+    }
+
+    #[test]
+    fn compares_sets_with_different_elements() {
+        let mut s1: Set<i32, 1> = Set::new();
+        s1.insert(1);
+
+        let mut s2: Set<i32, 1> = Set::new();
+        s2.insert(2);
+
+        assert_ne!(s1, s2);
+    }
+
+    #[test]
+    fn compares_sets_with_char_elements() {
+        let mut s1: Set<char, 2> = Set::new();
+        s1.insert('a');
+        s1.insert('b');
+
+        let mut s2: Set<char, 3> = Set::new();
+        s2.insert('a');
+        s2.insert('b');
+
+        assert_eq!(s1, s2);
+    }
+}

--- a/src/set/extend.rs
+++ b/src/set/extend.rs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023-2025 Yegor Bugayenko
+// SPDX-FileCopyrightText: Copyright (c) 2025 owtotwo
+// SPDX-License-Identifier: MIT
+
+use crate::Set;
+
+impl<T: PartialEq, const N: usize> Extend<T> for Set<T, N> {
+    #[inline]
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        iter.into_iter().for_each(|item| {
+            self.insert(item);
+        });
+    }
+}
+
+impl<'a, T: 'a + PartialEq + Copy, const N: usize> Extend<&'a T> for Set<T, N> {
+    #[inline]
+    fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
+        self.extend(iter.into_iter().copied());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::Set;
+
+    #[test]
+    fn extend_set_empty() {
+        let mut set = Set::<i32, 6>::new();
+        set.extend([1, 2, 3]);
+        assert_eq!(set, Set::from([1, 2, 3]));
+    }
+
+    #[test]
+    fn extend_set_not_empty() {
+        let mut set = Set::<i32, 6>::from_iter([1, 2]);
+        set.extend([1, 2, 3]);
+        assert_eq!(set, Set::from([1, 2, 3]));
+    }
+
+    #[test]
+    fn extend_set_overlap() {
+        let mut set = Set::<i32, 6>::from_iter([1, 2, 4]);
+        set.extend([2, 3, 5, 6]);
+        assert_eq!(set, Set::from([1, 2, 3, 4, 5, 6]));
+    }
+}

--- a/src/set/intersection.rs
+++ b/src/set/intersection.rs
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023-2025 Yegor Bugayenko
+// SPDX-FileCopyrightText: Copyright (c) 2025 owtotwo
+// SPDX-License-Identifier: MIT
+
+use crate::Set;
+use crate::SetIter;
+
+impl<T: PartialEq, const N: usize> Set<T, N> {
+    /// Visits the values representing the intersection,
+    /// i.e., the values that are both in `self` and `other`.
+    ///
+    /// When an equal element is present in `self` and `other`,
+    /// unlike the standard library functions, the resulting `Intersection`
+    /// will ALWAYS yield references to the caller(`self`). This can be
+    /// relevant if `T` contains fields which are not compared by its `Eq`
+    /// implementation, and may hold different value between the two equal
+    /// copies of `T` in the two sets.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use micromap::Set;
+    /// 
+    /// let a = Set::from([1, 2, 3]);
+    /// let b = Set::from([4, 2, 3, 4]);
+    ///
+    /// // Print 2, 3 in arbitrary order.
+    /// for x in a.intersection(&b) {
+    ///     println!("{x}");
+    /// }
+    ///
+    /// let intersection: Set<_, 3> = a.intersection(&b).collect();
+    /// assert_eq!(intersection, [2, 3].iter().collect());
+    /// ```
+    #[inline]
+    pub fn intersection<'a, const M: usize>(
+        &'a self,
+        other: &'a Set<T, M>,
+    ) -> Intersection<'a, T, M> {
+        Intersection {
+            iter: self.iter(),
+            other,
+        }
+    }
+}
+
+/// A lazy iterator producing elements in the intersection of Linear `Set`s.
+///
+/// This `struct` is created by the [`intersection`] method on [`Set`].
+/// See its documentation for more.
+///
+/// [`intersection`]: Set::intersection
+///
+/// # Examples
+///
+/// ```
+/// use micromap::Set;
+///
+/// let a = Set::from([1, 2, 3]);
+/// let b = Set::from([4, 2, 3, 4]);
+///
+/// let mut intersection = a.intersection(&b);
+/// ```
+pub struct Intersection<'a, T: 'a + PartialEq, const M: usize> {
+    // iterator of the first set
+    iter: SetIter<'a, T>,
+    // the second set
+    other: &'a Set<T, M>,
+}
+
+impl<T: PartialEq, const M: usize> Clone for Intersection<'_, T, M> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Intersection {
+            iter: self.iter.clone(),
+            ..*self
+        }
+    }
+}
+
+impl<'a, T: PartialEq, const M: usize> Iterator for Intersection<'a, T, M> {
+    type Item = &'a T;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.by_ref().find(|&item| self.other.contains(item))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.iter.size_hint();
+        let self_upper = upper.expect("Set's iter has the upper bound");
+        let other_upper = self.other.len();
+        (0, Some(usize::min(self_upper, other_upper)))
+    }
+
+    #[inline]
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        // Maybe using iterator is better than the default Iterator::fold() which uses while loop.
+        self.iter.fold(init, |acc, elt| {
+            if self.other.contains(elt) {
+                f(acc, elt)
+            } else {
+                acc
+            }
+        })
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T: std::fmt::Debug + PartialEq, const M: usize> std::fmt::Debug for Intersection<'_, T, M> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::Set;
+
+    #[test]
+    fn intersection_simple() {
+        let set_a = Set::from([0, 1, 2, 3, 5, 7, 9]);
+        let set_b = Set::from([2, 5, 6, 7, 8, 10]);
+        let set_c = Set::from([0, 1, 2, 3, 5, 7, 9, 2, 5, 6, 7, 8]);
+
+        let set_result: Set<_, 5> = set_a.intersection(&set_b).copied().collect();
+        assert_eq!(set_result, Set::from_iter([2, 5, 7]));
+        let set_result: Set<_, 7> = set_a.intersection(&set_c).copied().collect();
+        assert_eq!(set_result, set_a);
+        let set_result: Set<_, 6> = set_b.intersection(&set_c).copied().collect();
+        assert_eq!(set_result, Set::from_iter([2, 5, 6, 7, 8]));
+    }
+
+    #[test]
+    fn intersection_with_empty_set() {
+        let a = Set::from([1, 2, 3]);
+        let b: Set<i32, 3> = Set::new();
+        let intersection: Set<_, 3> = a.intersection(&b).collect();
+        assert!(intersection.is_empty());
+    }
+
+    #[test]
+    fn intersection_with_disjoint_sets() {
+        let a = Set::from([1, 2, 3]);
+        let b = Set::from([4, 5, 6]);
+        let intersection: Set<_, 3> = a.intersection(&b).collect();
+        assert!(intersection.is_empty());
+    }
+
+    #[test]
+    fn intersection_with_subset() {
+        let a = Set::from([1, 2, 3, 4]);
+        let b = Set::from([2, 3]);
+        let intersection: Set<_, 2> = a.intersection(&b).collect();
+        assert_eq!(intersection, [2, 3].iter().collect());
+    }
+
+    #[test]
+    fn intersection_with_superset() {
+        let a = Set::from([2, 3]);
+        let b = Set::from([1, 2, 3, 4]);
+        let intersection: Set<_, 2> = a.intersection(&b).collect();
+        assert_eq!(intersection, [2, 3].iter().collect());
+    }
+
+    #[test]
+    fn test_intersection_size_hint() {
+        let set_a: Set<u32, 5> = Set::from([0, 1, 3, 5, 7]);
+        let set_b: Set<u32, 4> = Set::from([1, 3, 5, 7]);
+
+        let intersection = set_a.intersection(&set_b);
+        let (lower, upper) = intersection.size_hint();
+
+        // Since all elements of set_b are in set_a, the upper bound should be the length of set_b
+        assert_eq!(lower, 0);
+        assert_eq!(upper, Some(set_b.len()));
+    }
+}

--- a/src/set/intersection.rs
+++ b/src/set/intersection.rs
@@ -111,9 +111,8 @@ impl<'a, T: PartialEq, const M: usize> Iterator for Intersection<'a, T, M> {
     }
 }
 
-#[cfg(feature = "std")]
-impl<T: std::fmt::Debug + PartialEq, const M: usize> std::fmt::Debug for Intersection<'_, T, M> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T: core::fmt::Debug + PartialEq, const M: usize> core::fmt::Debug for Intersection<'_, T, M> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
 }

--- a/src/set/intersection.rs
+++ b/src/set/intersection.rs
@@ -20,7 +20,7 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
     ///
     /// ```
     /// use micromap::Set;
-    /// 
+    ///
     /// let a = Set::from([1, 2, 3]);
     /// let b = Set::from([4, 2, 3, 4]);
     ///
@@ -29,8 +29,8 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
     ///     println!("{x}");
     /// }
     ///
-    /// let intersection: Set<_, 3> = a.intersection(&b).collect();
-    /// assert_eq!(intersection, [2, 3].iter().collect());
+    /// let intersection: Set<_, 3> = a.intersection(&b).copied().collect();
+    /// assert_eq!(intersection, Set::from([2, 3]));
     /// ```
     #[inline]
     pub fn intersection<'a, const M: usize>(
@@ -130,11 +130,11 @@ mod tests {
         let set_c = Set::from([0, 1, 2, 3, 5, 7, 9, 2, 5, 6, 7, 8]);
 
         let set_result: Set<_, 5> = set_a.intersection(&set_b).copied().collect();
-        assert_eq!(set_result, Set::from_iter([2, 5, 7]));
+        assert_eq!(set_result, Set::from([2, 5, 7]));
         let set_result: Set<_, 7> = set_a.intersection(&set_c).copied().collect();
         assert_eq!(set_result, set_a);
         let set_result: Set<_, 6> = set_b.intersection(&set_c).copied().collect();
-        assert_eq!(set_result, Set::from_iter([2, 5, 6, 7, 8]));
+        assert_eq!(set_result, Set::from([2, 5, 6, 7, 8]));
     }
 
     #[test]
@@ -149,7 +149,7 @@ mod tests {
     fn intersection_with_disjoint_sets() {
         let a = Set::from([1, 2, 3]);
         let b = Set::from([4, 5, 6]);
-        let intersection: Set<_, 3> = a.intersection(&b).collect();
+        let intersection: Set<_, 3> = a.intersection(&b).copied().collect();
         assert!(intersection.is_empty());
     }
 
@@ -157,16 +157,16 @@ mod tests {
     fn intersection_with_subset() {
         let a = Set::from([1, 2, 3, 4]);
         let b = Set::from([2, 3]);
-        let intersection: Set<_, 2> = a.intersection(&b).collect();
-        assert_eq!(intersection, [2, 3].iter().collect());
+        let intersection: Set<_, 2> = a.intersection(&b).copied().collect();
+        assert_eq!(intersection, Set::from([2, 3]));
     }
 
     #[test]
     fn intersection_with_superset() {
         let a = Set::from([2, 3]);
         let b = Set::from([1, 2, 3, 4]);
-        let intersection: Set<_, 2> = a.intersection(&b).collect();
-        assert_eq!(intersection, [2, 3].iter().collect());
+        let intersection: Set<_, 2> = a.intersection(&b).copied().collect();
+        assert_eq!(intersection, Set::from([2, 3]));
     }
 
     #[test]

--- a/src/set/iterators.rs
+++ b/src/set/iterators.rs
@@ -15,6 +15,15 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
     }
 }
 
+impl<T> Clone for SetIter<'_, T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        SetIter {
+            iter: self.iter.clone(),
+        }
+    }
+}
+
 impl<'a, T> Iterator for SetIter<'a, T> {
     type Item = &'a T;
 

--- a/src/set/methods.rs
+++ b/src/set/methods.rs
@@ -104,3 +104,102 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
         self.map.remove_entry(k).map(|p| p.0)
     }
 }
+
+/// Specialized methods available only on [`Set`].
+impl<T: PartialEq, const N: usize> Set<T, N> {
+    /// Returns `true` if `self` has no elements in common with `other`.
+    /// This is equivalent to checking for an empty intersection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use micromap::Set;
+    ///
+    /// let a = Set::from([1, 2, 3]);
+    /// let mut b: Set<u32, 5> = Set::new();
+    ///
+    /// assert_eq!(a.is_disjoint(&b), true);
+    /// b.insert(4);
+    /// assert_eq!(a.is_disjoint(&b), true);
+    /// b.insert(1);
+    /// assert_eq!(a.is_disjoint(&b), false);
+    /// ```
+    pub fn is_disjoint<const M: usize>(&self, other: &'_ Set<T, M>) -> bool {
+        if self.len() <= other.len() {
+            self.iter().all(|v| !other.contains(v))
+        } else {
+            other.iter().all(|v| !self.contains(v))
+        }
+    }
+
+    /// Returns `true` if the set is a subset of another,
+    /// i.e., `other` contains at least all the values in `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use micromap::Set;
+    ///
+    /// let sup = Set::from([1, 2, 3]);
+    /// let mut set: Set<u32, 5> = Set::new();
+    ///
+    /// assert_eq!(set.is_subset(&sup), true);
+    /// set.insert(2);
+    /// assert_eq!(set.is_subset(&sup), true);
+    /// set.insert(4);
+    /// assert_eq!(set.is_subset(&sup), false);
+    /// ```
+    pub fn is_subset<const M: usize>(&self, other: &'_ Set<T, M>) -> bool {
+        if self.len() <= other.len() {
+            self.iter().all(|v| other.contains(v))
+        } else {
+            false
+        }
+    }
+
+    /// Returns `true` if the set is a superset of another,
+    /// i.e., `self` contains at least all the values in `other`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use micromap::Set;
+    ///
+    /// let sub = Set::from([1, 2]);
+    /// let mut set: Set<u32, 5> = Set::new();
+    ///
+    /// assert_eq!(set.is_superset(&sub), false);
+    ///
+    /// set.insert(0);
+    /// set.insert(1);
+    /// assert_eq!(set.is_superset(&sub), false);
+    ///
+    /// set.insert(2);
+    /// assert_eq!(set.is_superset(&sub), true);
+    /// ```
+    #[inline]
+    pub fn is_superset<const M: usize>(&self, other: &'_ Set<T, M>) -> bool {
+        other.is_subset(self)
+    }
+
+    /// Adds a value to the set, replacing the existing value, if any, that is equal to the given
+    /// one. Returns the replaced value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use micromap::Set;
+    ///
+    /// let mut set: Set<_, 5> = Set::new();
+    /// set.insert(Vec::<i32>::new());
+    ///
+    /// assert_eq!(set.get(&[][..]).unwrap().capacity(), 0);
+    /// set.replace(Vec::with_capacity(10));
+    /// assert_eq!(set.get(&[][..]).unwrap().capacity(), 10);
+    /// ```
+    #[inline]
+    pub fn replace(&mut self, value: T) -> Option<T> {
+        let (_, existing_pair) = self.map.insert_i(value, ());
+        existing_pair.map(|(k, ())| k)
+    }
+}

--- a/src/set/mod.rs
+++ b/src/set/mod.rs
@@ -16,7 +16,7 @@ mod serialization;
 use crate::Map;
 
 pub mod difference;
-// pub mod intersection;
+pub mod intersection;
 // pub mod symmetric_difference;
 // pub mod union;
 

--- a/src/set/mod.rs
+++ b/src/set/mod.rs
@@ -8,8 +8,8 @@ mod display;
 mod drain;
 mod eq;
 mod from;
-mod functions;
 mod iterators;
+mod methods;
 #[cfg(feature = "serde")]
 mod serialization;
 

--- a/src/set/mod.rs
+++ b/src/set/mod.rs
@@ -17,8 +17,8 @@ use crate::Map;
 
 pub mod difference;
 pub mod intersection;
-// pub mod symmetric_difference;
-// pub mod union;
+pub mod symmetric_difference;
+pub mod union;
 
 /// A faster alternative of [`std::collections::HashSet`].
 ///

--- a/src/set/mod.rs
+++ b/src/set/mod.rs
@@ -136,8 +136,8 @@ mod tests {
     #[test]
     fn test_set_from() {
         let set_a = Set::from(['a', 'b', 'c', 'd']);
-        let set_b = Set::from_iter(vec!['a', 'a', 'd', 'b', 'a', 'd', 'c', 'd', 'c']);
-        let set_c = Set::from_iter(set_a.clone());
+        let set_b: Set<_, 6> = Set::from_iter(['a', 'a', 'd', 'b', 'a', 'd', 'c', 'd', 'c']);
+        let set_c = set_a.clone();
         assert_eq!(set_a, set_b);
         assert_eq!(set_a, set_c);
     }

--- a/src/set/mod.rs
+++ b/src/set/mod.rs
@@ -4,21 +4,21 @@
 mod clone;
 mod ctors;
 mod debug;
+mod difference;
 mod display;
 mod drain;
 mod eq;
+mod extend;
 mod from;
+mod intersection;
 mod iterators;
 mod methods;
 #[cfg(feature = "serde")]
 mod serialization;
+mod symmetric_difference;
+mod union;
 
 use crate::Map;
-
-pub mod difference;
-pub mod intersection;
-pub mod symmetric_difference;
-pub mod union;
 
 /// A faster alternative of [`std::collections::HashSet`].
 ///

--- a/src/set/mod.rs
+++ b/src/set/mod.rs
@@ -15,6 +15,11 @@ mod serialization;
 
 use crate::Map;
 
+pub mod difference;
+// pub mod intersection;
+// pub mod symmetric_difference;
+// pub mod union;
+
 /// A faster alternative of [`std::collections::HashSet`].
 ///
 /// For example, this is how you make a set, which is allocated on stack and is capable of storing

--- a/src/set/symmetric_difference.rs
+++ b/src/set/symmetric_difference.rs
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023-2025 Yegor Bugayenko
+// SPDX-FileCopyrightText: Copyright (c) 2025 owtotwo
+// SPDX-License-Identifier: MIT
+
+use crate::set::difference::Difference;
+use crate::Set;
+
+impl<T: PartialEq, const N: usize> Set<T, N> {
+    /// Visits the values representing the symmetric difference,
+    /// i.e., the values that are in `self` or `other` but not in both.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use micromap::Set;
+    ///
+    /// let a = Set::from([1, 2, 3]);
+    /// let b = Set::from([4, 2, 3, 4]);
+    ///
+    /// // Can be seen as `(a - b) ∪ (b - a)`.
+    /// for x in a.symmetric_difference(&b) {
+    ///     println!("{x}"); // Print 1, 4
+    /// }
+    ///
+    /// let sym_diff: Set<_, 7> = a.symmetric_difference(&b).copied().collect();
+    /// assert_eq!(sym_diff, Set::from([1, 4]));
+    /// ```
+    #[inline]
+    pub fn symmetric_difference<'a, const M: usize>(
+        &'a self,
+        other: &'a Set<T, M>,
+    ) -> SymmetricDifference<'a, T, N, M> {
+        SymmetricDifference {
+            iter: self.difference(other).chain(other.difference(self)),
+        }
+    }
+}
+
+/// A lazy iterator producing elements in the symmetric difference of Linear `Set`s.
+///
+/// This `struct` is created by the [`symmetric_difference`] method on [`Set`].
+///
+/// [`symmetric_difference`]: Set::symmetric_difference
+///
+/// # Examples
+///
+/// ```
+/// use micromap::Set;
+///
+/// let a = Set::from([1, 2, 3]);
+/// let b = Set::from([4, 2, 3, 4]);
+///
+/// let mut sym_diff = a.symmetric_difference(&b);
+/// ```
+#[must_use = "this returns the difference as an iterator, without modifying either input set"]
+pub struct SymmetricDifference<'a, T: 'a + PartialEq, const N: usize, const M: usize> {
+    iter: core::iter::Chain<Difference<'a, T, M>, Difference<'a, T, N>>,
+}
+
+impl<T: PartialEq, const N: usize, const M: usize> Clone for SymmetricDifference<'_, T, N, M> {
+    #[inline]
+    fn clone(&self) -> Self {
+        SymmetricDifference {
+            iter: self.iter.clone(),
+        }
+    }
+}
+
+impl<'a, T: PartialEq, const N: usize, const M: usize> Iterator
+    for SymmetricDifference<'a, T, N, M>
+{
+    type Item = &'a T;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+
+    #[inline]
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.iter.fold(init, f)
+    }
+}
+
+impl<T: core::fmt::Debug + PartialEq, const N: usize, const M: usize> core::fmt::Debug
+    for SymmetricDifference<'_, T, N, M>
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
+    }
+}
+
+impl<T: PartialEq, const N: usize, const M: usize> core::iter::FusedIterator
+    for SymmetricDifference<'_, T, N, M>
+{
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::Set;
+
+    #[test]
+    fn symmetric_difference_simple() {
+        let set_a = Set::from([0, 1, 2, 3, 5, 7, 9]);
+        let set_b = Set::from([2, 5, 6, 7, 8, 10]);
+        let set_c = Set::from([0, 1, 2, 3, 5, 7, 9, 2, 5, 6, 7, 8]);
+
+        let set_result: Set<_, 13> = set_a.symmetric_difference(&set_b).copied().collect();
+        assert_eq!(set_result, Set::from([0, 1, 3, 6, 8, 9, 10]));
+        let set_result: Set<_, 19> = set_a.symmetric_difference(&set_c).copied().collect();
+        assert_eq!(set_result, Set::from([6, 8]));
+        let set_result: Set<_, 18> = set_b.symmetric_difference(&set_c).copied().collect();
+        assert_eq!(set_result, Set::from([0, 1, 3, 9, 10]));
+    }
+
+    #[test]
+    fn symmetric_difference_with_empty_set() {
+        let set_a = Set::from([1, 2, 3]);
+        let set_b: Set<i32, 3> = Set::new();
+        let sym_diff: Set<_, 6> = set_a.symmetric_difference(&set_b).copied().collect();
+        assert_eq!(sym_diff, set_a);
+    }
+
+    #[test]
+    fn symmetric_difference_with_disjoint_sets() {
+        let a = Set::from([1, 2, 3]);
+        let b = Set::from([4, 5, 6]);
+        let sym_diff: Set<_, 6> = a.symmetric_difference(&b).copied().collect();
+        assert_eq!(sym_diff, Set::from([1, 2, 3, 4, 5, 6]));
+    }
+
+    #[test]
+    fn symmetric_difference_with_subset() {
+        let a = Set::from([1, 2, 3, 4]);
+        let b = Set::from([2, 3]);
+        let sym_diff: Set<_, 6> = a.symmetric_difference(&b).copied().collect();
+        assert_eq!(sym_diff, Set::from([1, 4]));
+    }
+
+    #[test]
+    fn symmetric_difference_with_superset() {
+        let a = Set::from([2, 3]);
+        let b = Set::from([1, 2, 3, 4]);
+        let sym_diff: Set<_, 6> = a.symmetric_difference(&b).copied().collect();
+        assert_eq!(sym_diff, Set::from([1, 4]));
+    }
+
+    #[test]
+    fn symmetric_difference_size_hint() {
+        let set_a = Set::from([1, 1, 2, 3]); // cap is 4, but len() is 3
+        let set_b = Set::from([4, 5, 6, 6, 6, 7, 8, 9]); // cap is 8, but len() is 6
+        let set_c = Set::from([]);
+        let set_d = Set::from([3, 4]);
+
+        assert_eq!(set_a.symmetric_difference(&set_b).size_hint(), (3, Some(9)));
+        assert_eq!(set_a.symmetric_difference(&set_c).size_hint(), (3, Some(3)));
+        assert_eq!(set_a.symmetric_difference(&set_d).size_hint(), (1, Some(5)));
+
+        assert_eq!(set_b.symmetric_difference(&set_a).size_hint(), (3, Some(9)));
+        assert_eq!(set_b.symmetric_difference(&set_d).size_hint(), (4, Some(8)));
+
+        assert_eq!(set_c.symmetric_difference(&set_b).size_hint(), (6, Some(6)));
+
+        assert_eq!(set_d.symmetric_difference(&set_a).size_hint(), (1, Some(5)));
+        assert_eq!(set_d.symmetric_difference(&set_b).size_hint(), (4, Some(8)));
+        assert_eq!(set_d.symmetric_difference(&set_c).size_hint(), (2, Some(2)));
+    }
+}

--- a/src/set/union.rs
+++ b/src/set/union.rs
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023-2025 Yegor Bugayenko
+// SPDX-FileCopyrightText: Copyright (c) 2025 owtotwo
+// SPDX-License-Identifier: MIT
+
+use crate::set::difference::Difference;
+use crate::Set;
+use crate::SetIter;
+
+impl<T: PartialEq, const N: usize> Set<T, N> {
+    /// Visits the values representing the union,
+    /// i.e., the values that are in `self` or `other`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use micromap::Set;
+    ///
+    /// let a = Set::from([1, 2, 3]);
+    /// let b = Set::from([4, 2, 3, 4]);
+    ///
+    /// // Can be seen as `a ∪ b`.
+    /// for x in a.union(&b) {
+    ///     println!("{x}"); // Print 1, 2, 3, 4
+    /// }
+    ///
+    /// let union: Set<_, 7> = a.union(&b).copied().collect();
+    /// assert_eq!(union, Set::from([1, 2, 3, 4]));
+    /// ```
+    #[inline]
+    pub fn union<'a, const M: usize>(&'a self, other: &'a Set<T, M>) -> Union<'a, T, M> {
+        Union {
+            iter: other.iter().chain(self.difference(other)),
+        }
+    }
+}
+
+/// A lazy iterator producing elements in the union of Linear `Set`s.
+///
+/// This `struct` is created by the [`union`] method on [`Set`].
+///
+/// [`union`]: Set::union
+///
+/// # Examples
+///
+/// ```
+/// use micromap::Set;
+///
+/// let a = Set::from([1, 2, 3]);
+/// let b = Set::from([4, 2, 3, 4]);
+///
+/// let mut union = a.union(&b);
+/// ```
+#[must_use = "this returns the union as an iterator, without modifying either input set"]
+pub struct Union<'a, T: 'a + PartialEq, const M: usize> {
+    iter: core::iter::Chain<SetIter<'a, T>, Difference<'a, T, M>>,
+}
+
+impl<T: PartialEq, const M: usize> Clone for Union<'_, T, M> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Union {
+            iter: self.iter.clone(),
+        }
+    }
+}
+
+impl<'a, T: PartialEq, const M: usize> Iterator for Union<'a, T, M> {
+    type Item = &'a T;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+
+    #[inline]
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.iter.fold(init, f)
+    }
+}
+
+impl<T: core::fmt::Debug + PartialEq, const M: usize> core::fmt::Debug for Union<'_, T, M> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
+    }
+}
+
+impl<T: PartialEq, const M: usize> core::iter::FusedIterator for Union<'_, T, M> {}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::Set;
+
+    #[test]
+    fn union_simple() {
+        let set_a = Set::from([0, 1, 2, 3, 5, 7, 9]);
+        let set_b = Set::from([2, 5, 6, 7, 8, 10]);
+        let set_c = Set::from([0, 1, 2, 3, 5, 7, 9, 2, 5, 6, 7, 8]);
+
+        let set_result: Set<_, 13> = set_a.union(&set_b).copied().collect();
+        assert_eq!(set_result, Set::from([0, 1, 2, 3, 5, 6, 7, 8, 9, 10]));
+        let set_result: Set<_, 19> = set_a.union(&set_c).copied().collect();
+        assert_eq!(set_result, Set::from([0, 1, 2, 3, 5, 6, 7, 8, 9]));
+        let set_result: Set<_, 18> = set_b.union(&set_c).copied().collect();
+        assert_eq!(set_result, Set::from([0, 1, 2, 3, 5, 6, 7, 8, 9, 10]));
+    }
+
+    #[test]
+    fn union_with_empty_set() {
+        let set_a = Set::from([1, 2, 3]);
+        let set_b: Set<i32, 3> = Set::new();
+        let union: Set<_, 6> = set_a.union(&set_b).copied().collect();
+        assert_eq!(union, set_a);
+    }
+
+    #[test]
+    fn union_with_disjoint_sets() {
+        let a = Set::from([1, 2, 3]);
+        let b = Set::from([4, 5, 6]);
+        let union: Set<_, 6> = a.union(&b).copied().collect();
+        assert_eq!(union, Set::from([1, 2, 3, 4, 5, 6]));
+    }
+
+    #[test]
+    fn union_with_subset() {
+        let a = Set::from([1, 2, 3, 4]);
+        let b = Set::from([2, 3]);
+        let union: Set<_, 6> = a.union(&b).copied().collect();
+        assert_eq!(union, Set::from([1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn union_with_superset() {
+        let a = Set::from([2, 3]);
+        let b = Set::from([1, 2, 3, 4]);
+        let union: Set<_, 6> = a.union(&b).copied().collect();
+        assert_eq!(union, Set::from([1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn union_size_hint() {
+        let set_a = Set::from([1, 1, 2, 3]); // cap is 4, but len() is 3
+        let set_b = Set::from([4, 5, 6, 6, 6, 7, 8, 9]); // cap is 8, but len() is 6
+        let set_c = Set::from([]);
+        let set_d = Set::from([3, 4]);
+
+        assert_eq!(set_a.union(&set_b).size_hint(), (6, Some(9)));
+        assert_eq!(set_a.union(&set_c).size_hint(), (3, Some(3)));
+        assert_eq!(set_a.union(&set_d).size_hint(), (3, Some(5)));
+
+        assert_eq!(set_b.union(&set_a).size_hint(), (6, Some(9)));
+        assert_eq!(set_b.union(&set_d).size_hint(), (6, Some(8)));
+
+        assert_eq!(set_c.union(&set_b).size_hint(), (6, Some(6)));
+
+        assert_eq!(set_d.union(&set_a).size_hint(), (3, Some(5)));
+        assert_eq!(set_d.union(&set_b).size_hint(), (6, Some(8)));
+        assert_eq!(set_d.union(&set_c).size_hint(), (2, Some(2)));
+    }
+}


### PR DESCRIPTION
- **`difference()`**
- **`intersection()`**
- **`symmetric_difference()`**
- **`union()`**
- `is_disjoint()`
- `is_subset()`
- `is_superset()`
- **`replace()`**

Note: Although some of the Map code was modified during the writing of the Set code, it did not affect the core logic. **So the benchmark results did not change, I just add almost fully functionality to `Set`**. (Of course, maybe it’s time for us to benchmark Set.)