### PR TITLE
For optimization, use `.pairs.get_unchecked_xx(i)` to replace the `.pairs[i]`, which has bound check.

### DIFF
--- a/src/clone.rs
+++ b/src/clone.rs
@@ -7,7 +7,7 @@ impl<K: Clone + PartialEq, V: Clone, const N: usize> Clone for Map<K, V, N> {
     fn clone(&self) -> Self {
         let mut m: Self = Self::new();
         for i in 0..self.len {
-            m.item_write(i, self.item_ref(i).clone());
+            unsafe { m.item_write(i, self.item_ref(i).clone()) };
         }
         m.len = self.len;
         m

--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -21,11 +21,9 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     #[must_use]
     #[allow(clippy::uninit_assumed_init)]
     pub const fn new() -> Self {
-        unsafe {
-            Self {
-                len: 0,
-                pairs: MaybeUninit::<[MaybeUninit<(K, V)>; N]>::uninit().assume_init(),
-            }
+        Self {
+            len: 0,
+            pairs: [const { MaybeUninit::uninit() }; N],
         }
     }
 }
@@ -33,7 +31,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
 impl<K: PartialEq, V, const N: usize> Drop for Map<K, V, N> {
     fn drop(&mut self) {
         for i in 0..self.len {
-            self.item_drop(i);
+            unsafe { self.item_drop(i) };
         }
     }
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -5,7 +5,7 @@ use crate::Map;
 use core::fmt::{self, Debug, Formatter};
 
 impl<K: PartialEq + Debug, V: Debug, const N: usize> Debug for Map<K, V, N> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_map().entries(self.iter()).finish()
     }
 }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -63,26 +63,26 @@ impl<'a, K: PartialEq, V: Default, const N: usize> Entry<'a, K, V, N> {
 impl<'a, K: PartialEq, V, const N: usize> OccupiedEntry<'a, K, V, N> {
     #[must_use]
     pub fn key(&self) -> &K {
-        &self.table.item_ref(self.index).0
+        unsafe { &self.table.item_ref(self.index).0 }
     }
 
     #[must_use]
     pub fn remove_entry(self) -> (K, V) {
-        self.table.remove_index_read(self.index)
+        unsafe { self.table.remove_index_read(self.index) }
     }
 
     #[must_use]
     pub fn get(&self) -> &V {
-        &self.table.item_ref(self.index).1
+        unsafe { &self.table.item_ref(self.index).1 }
     }
 
     pub fn get_mut(&mut self) -> &mut V {
-        self.table.item_mut(self.index)
+        unsafe { self.table.item_mut(self.index) }
     }
 
     #[must_use]
     pub fn into_mut(self) -> &'a mut V {
-        self.table.item_mut(self.index)
+        unsafe { self.table.item_mut(self.index) }
     }
 
     pub fn insert(&mut self, value: V) -> V {
@@ -91,7 +91,7 @@ impl<'a, K: PartialEq, V, const N: usize> OccupiedEntry<'a, K, V, N> {
 
     #[must_use]
     pub fn remove(self) -> V {
-        self.table.remove_index_read(self.index).1
+        unsafe { self.table.remove_index_read(self.index).1 }
     }
 }
 
@@ -106,7 +106,7 @@ impl<'a, K: PartialEq, V, const N: usize> VacantEntry<'a, K, V, N> {
 
     pub fn insert(self, value: V) -> &'a mut V {
         let (index, _) = self.table.insert_i(self.key, value);
-        self.table.item_mut(index)
+        unsafe { self.table.item_mut(index) }
     }
 }
 

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -8,14 +8,18 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     /// Make an iterator over all pairs.
     #[inline]
     #[must_use]
-    pub fn iter(&self) -> Iter<K, V> {
-        self.into_iter()
+    pub fn iter(&self) -> Iter<'_, K, V> {
+        Iter {
+            iter: self.pairs[..self.len].as_ref().iter(),
+        }
     }
 
     /// An iterator with mutable references to the values but
     #[inline]
-    pub fn iter_mut(&mut self) -> IterMut<K, V> {
-        self.into_iter()
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
+        IterMut {
+            iter: self.pairs[..self.len].as_mut().iter_mut(),
+        }
     }
 }
 
@@ -102,9 +106,7 @@ impl<'a, K: PartialEq, V, const N: usize> IntoIterator for &'a Map<K, V, N> {
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        Iter {
-            iter: self.pairs[0..self.len].iter(),
-        }
+        self.iter()
     }
 }
 
@@ -114,9 +116,7 @@ impl<'a, K: PartialEq, V, const N: usize> IntoIterator for &'a mut Map<K, V, N> 
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        IterMut {
-            iter: self.pairs[0..self.len].iter_mut(),
-        }
+        self.iter_mut()
     }
 }
 

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -83,7 +83,7 @@ impl<K: PartialEq, V, const N: usize> Iterator for IntoIter<K, V, N> {
     fn next(&mut self) -> Option<Self::Item> {
         if self.map.len > 0 {
             self.map.len -= 1;
-            Some(self.map.item_read(self.map.len))
+            Some(unsafe { self.map.item_read(self.map.len) })
         } else {
             None
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 #![doc(html_root_url = "https://docs.rs/micromap/0.0.0")]
 #![deny(warnings)]
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
+#![warn(rust_2018_idioms)]
 #![allow(clippy::multiple_inherent_impl)]
 #![allow(clippy::multiple_crate_versions)]
 
@@ -138,7 +139,7 @@ pub struct IntoKeys<K: PartialEq, V, const N: usize> {
 /// This `enum` is constructed from the [`entry`] method on [`Map`].
 ///
 /// [`entry`]: Map::entry
-pub enum Entry<'a, K: 'a + PartialEq, V: 'a, const N: usize> {
+pub enum Entry<'a, K: PartialEq, V, const N: usize> {
     /// An occupied entry.
     Occupied(OccupiedEntry<'a, K, V, N>),
 
@@ -148,14 +149,14 @@ pub enum Entry<'a, K: 'a + PartialEq, V: 'a, const N: usize> {
 
 /// A view into an occupied entry in a `Map`.
 /// It is part of the [`Entry`] enum.
-pub struct OccupiedEntry<'a, K: 'a + PartialEq, V: 'a, const N: usize> {
+pub struct OccupiedEntry<'a, K: PartialEq, V, const N: usize> {
     index: usize,
     table: &'a mut Map<K, V, N>,
 }
 
 /// A view into a vacant entry in a `Map`.
 /// It is part of the [`Entry`] enum.
-pub struct VacantEntry<'a, K: 'a + PartialEq, V: 'a, const N: usize> {
+pub struct VacantEntry<'a, K: PartialEq, V, const N: usize> {
     key: K,
     table: &'a mut Map<K, V, N>,
 }
@@ -164,6 +165,6 @@ pub struct VacantEntry<'a, K: 'a + PartialEq, V: 'a, const N: usize> {
 ///
 /// This struct is created by the drain method on `Map`. See its documentation for more.
 #[deny(clippy::needless_lifetimes)]
-pub struct Drain<'a, K: 'a, V: 'a> {
+pub struct Drain<'a, K, V> {
     iter: core::slice::IterMut<'a, MaybeUninit<(K, V)>>,
 }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -28,7 +28,7 @@ impl<'de, K: PartialEq + Deserialize<'de>, V: Deserialize<'de>, const N: usize> 
 {
     type Value = Map<K, V, N>;
 
-    fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter<'_>) -> core::fmt::Result {
         formatter.write_str("a Map")
     }
 

--- a/src/set/debug.rs
+++ b/src/set/debug.rs
@@ -5,7 +5,7 @@ use crate::Set;
 use core::fmt::{self, Debug, Formatter};
 
 impl<T: PartialEq + Debug, const N: usize> Debug for Set<T, N> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_set().entries(self.iter()).finish()
     }
 }

--- a/src/set/intersection.rs
+++ b/src/set/intersection.rs
@@ -62,7 +62,7 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
 /// let mut intersection = a.intersection(&b);
 /// ```
 #[must_use = "this returns the intersection as an iterator, without modifying either input set"]
-pub struct Intersection<'a, T: 'a + PartialEq, const M: usize> {
+pub struct Intersection<'a, T: PartialEq, const M: usize> {
     // iterator of the first set
     iter: SetIter<'a, T>,
     // the second set

--- a/src/set/iterators.rs
+++ b/src/set/iterators.rs
@@ -8,7 +8,7 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
     /// Make an iterator over all pairs.
     #[inline]
     #[must_use]
-    pub fn iter(&self) -> SetIter<T> {
+    pub fn iter(&self) -> SetIter<'_, T> {
         SetIter {
             iter: self.map.keys(),
         }

--- a/src/set/serialization.rs
+++ b/src/set/serialization.rs
@@ -26,7 +26,7 @@ struct Vi<T, const N: usize>(PhantomData<T>);
 impl<'de, T: PartialEq + Deserialize<'de>, const N: usize> Visitor<'de> for Vi<T, N> {
     type Value = Set<T, N>;
 
-    fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter<'_>) -> core::fmt::Result {
         formatter.write_str("a Set")
     }
 

--- a/src/set/symmetric_difference.rs
+++ b/src/set/symmetric_difference.rs
@@ -53,7 +53,7 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
 /// let mut sym_diff = a.symmetric_difference(&b);
 /// ```
 #[must_use = "this returns the difference as an iterator, without modifying either input set"]
-pub struct SymmetricDifference<'a, T: 'a + PartialEq, const N: usize, const M: usize> {
+pub struct SymmetricDifference<'a, T: PartialEq, const N: usize, const M: usize> {
     iter: core::iter::Chain<Difference<'a, T, M>, Difference<'a, T, N>>,
 }
 

--- a/src/set/union.rs
+++ b/src/set/union.rs
@@ -51,7 +51,7 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
 /// let mut union = a.union(&b);
 /// ```
 #[must_use = "this returns the union as an iterator, without modifying either input set"]
-pub struct Union<'a, T: 'a + PartialEq, const M: usize> {
+pub struct Union<'a, T: PartialEq, const M: usize> {
     iter: core::iter::Chain<SetIter<'a, T>, Difference<'a, T, M>>,
 }
 


### PR DESCRIPTION
- And add the strict lint about lifetime: `#![warn(rust_2018_idioms)]`;
- Mark `unsafe fn` for the `internal::item_xxx()` functions which is memory unsafe.
- Ensure that they meet the safety requirements before calling them. (No new code is added, the previous code already meets this requirement).
- add `Safety` part to comment doc.
- The optimization result is in the commit information, **it is a positive optimization**.