### PR TITLE
Bump the dep crate `bincode` from v1.3.3 to v2.0.1, do the Migrating.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,11 +29,12 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
  "serde",
+ "unty",
 ]
 
 [[package]]
@@ -375,6 +376,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ categories = ["data-structures", "memory-management"]
 
 [dependencies]
 serde = { version = "1.0.200", optional = true, default-features = false }
+bincode = { version = "2.0.1", optional = true, default-features = false, features = ["serde"] }
 
 [dev-dependencies]
-bincode = "1.3.3"
 hashbrown = "0.15.0"
 heapless = "0.8.0"
 rustc-hash = "2.0.0"
@@ -32,3 +32,4 @@ flurry = "0.5.2"
 [features]
 default = []
 std = []
+serde = ["dep:serde", "dep:bincode"]

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -69,7 +69,6 @@ mod tests {
         let mut bytes: [u8; 1024] = [0; 1024];
         let len = encode_into_slice(&before, &mut bytes, config).unwrap();
         let bytes = &bytes[..len];
-        println!("bytes: {:?}", bytes);
         let (after, read_len): (Map<u8, u8, 8>, usize) = decode_from_slice(&bytes, config).unwrap();
         assert_eq!(42, after.into_iter().next().unwrap().1);
         assert_eq!(bytes.len(), read_len);

--- a/src/set/difference.rs
+++ b/src/set/difference.rs
@@ -209,7 +209,6 @@ mod tests {
 
     // NOTE: This is a BUG in the standard library function.
     #[test]
-    #[ignore]
     fn difference_lifetime() {
         // use std::collections::hash_set::HashSet as Set;
 


### PR DESCRIPTION
- And add the new non-default feature "serde" for us.
- > Starting from bincode 2, serde is now an optional dependency. 
(From: https://github.com/bincode-org/bincode/blob/508a00bb17fda81da1ad2b3856669c27b7fe5dbd/src/lib.rs#L10-L14)
- We migrated with `serde`. (Ref: https://github.com/bincode-org/bincode/blob/508a00bb17fda81da1ad2b3856669c27b7fe5dbd/docs/migration_guide.md?plain=1#L41-L65)