### PR TITLE
add `checked_insert()` api for fixed-capacity map, which will not panic when full.

### DIFF
--- a/examples/lru_cache.rs
+++ b/examples/lru_cache.rs
@@ -128,7 +128,8 @@ mod map_in_lru {
     }
 
     impl<K: PartialEq, V, const N: usize> WithCapacity for MicroMap<K, V, N> {
-        fn with_capacity(_capacity: usize) -> Self {
+        fn with_capacity(capacity: usize) -> Self {
+            assert_eq!(capacity, N);
             MicroMap::<K, V, N>::new()
         }
     }


### PR DESCRIPTION
Because the capacity of the map is fixed, it is common to check and insert after it when the map is full. 
And it is possible that the insertion is just a replacement, and the size of the map remains unchanged, that is, insertion into a full map is likely to succeed.

tldr: like [u8::checked_add](https://doc.rust-lang.org/1.85.1/std/primitive.u8.html#method.checked_add) in Rust std library, it returns None if overflow occurred.
> pub const fn checked_add(self, rhs: u8) -> Option\<u8\>

---

For variable-capacity hashmaps, this method is not needed, so the hashmap in the Rust standard library, which can automatically expand in capacity, does not have this API.

But for our fixed-capacity Linear Map, whether it is full is a point that must be considered. 
Before this method, when the map is full, we can use `contains_key(k)` to query whether the same key already exists and `insert()` (replace), so that the insertion (query again) can ensure that no panic is triggered. But we provide this convenient function, which only performs one query. So the existence of this function is very meaningful in fixed-capacity map.

About its API naming, we have `insert()`, `insert_unchecked()` and `checked_insert()` now.
Considering that users may have questions about method naming, here is an explanation:
- `insert()`: the normal one, return Option<V>. (the old key-value pair by replacing or None by new insertion)
- `insert_unchecked()`: similar to `insert()`, but hit the [UB](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) instead of panic. so it marks `unsafe`.
- `checked_insert()`: when map is full and new key-value pair can not be inserted, it will return None.
  + But why not name it `insert_checked()` or `try_insert()`? Because in Rust std library, between `checked_xxx()` api and `doxxx_unchecked()` api are not related. 
  + The former means whether the method itself will perform out-of-bounds checking and return `Option::None` to indicate out-of-bounds.
  + The latter means that the method itself skips the check and does not guarantee `Safety`, but requires the user to ensure that. In many performance-oriented codes, methods like [`slice::get_unchecked()`](https://doc.rust-lang.org/1.85.1/std/primitive.slice.html#method.get_unchecked) are necessary.
  + About the `try_insert()`, we can check the [`Try`](https://doc.rust-lang.org/1.85.1/std/ops/trait.Try.html) trait, and [`u8::try_from()`](https://doc.rust-lang.org/1.85.1/std/primitive.u8.html#method.try_from). The `try_xx()` API also means "may fail when called", but that's it. In contrast, `checked_xx()` includes "we will do check during execution, and if it is found that it cannot be executed, we will return `Option::None`", which is more in line with its semantics.