### PR TITLE
add new api `get_disjoint_mut()` (and _unchecked ver) with some unit tests

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -393,14 +393,12 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
         if ks.is_empty() {
             return [const { None }; J];
         }
-
         // check for overlapping keys (O(n^2), but n is small)
         for (i, k) in ks[..ks.len() - 1].iter().enumerate() {
             for k_behind in &ks[i + 1..] {
                 assert!(k != k_behind, "Overlapping keys");
             }
         }
-
         unsafe { self.get_disjoint_unchecked_mut(ks) }
     }
 
@@ -468,14 +466,12 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
         Q: Eq + ?Sized,
     {
         let mut ret: [Option<&mut V>; J] = [const { None }; J];
-
         if ks.is_empty() {
             return ret;
         } else if ks.len() == 1 {
             ret[0] = self.get_mut(ks[0]);
             return ret;
         }
-
         // find the keys' index in one iteration of the map, store the result
         // into the stack.
         let mut stack = [const { None }; J];
@@ -487,9 +483,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
                 stack_top += 1;
             }
         }
-
         stack[..stack_top].sort_unstable_by_key(|x| x.map(|(pair_i, _)| pair_i));
-
         // start splitting the found pairs from the back to the front
         let mut rest_head = &mut self.pairs[..self.len];
         for (pair_i, ks_i) in stack[..stack_top].iter().rev().flatten() {

--- a/src/map.rs
+++ b/src/map.rs
@@ -820,12 +820,10 @@ mod tests {
         map.insert("key2", 20);
         map.insert("key3", 30);
         map.insert("key4", 40);
-
         let [v3, v1, v2] = map.get_disjoint_mut(["key3", "key1", "key2"]);
         assert_eq!(v1, Some(&mut 10));
         assert_eq!(v2, Some(&mut 20));
         assert_eq!(v3, Some(&mut 30));
-
         if let Some(v1) = v1 {
             *v1 = 100;
         }
@@ -835,7 +833,6 @@ mod tests {
         if let Some(v3) = v3 {
             *v3 = 300;
         }
-
         assert_eq!(map.get("key1"), Some(&100));
         assert_eq!(map.get("key2"), Some(&200));
         assert_eq!(map.get("key3"), Some(&300));
@@ -848,7 +845,6 @@ mod tests {
         let mut map: Map<&str, i32, 5> = Map::new();
         map.insert("key1", 10);
         map.insert("key2", 20);
-
         // This should panic because the keys overlap.
         let _ = map.get_disjoint_mut(["key1", "key1"]);
     }
@@ -857,7 +853,6 @@ mod tests {
     fn get_disjoint_mut_missing_keys() {
         let mut map: Map<&str, i32, 5> = Map::new();
         map.insert("key2", 20);
-
         let [v1, v2] = map.get_disjoint_mut(["key1", "key2"]);
         assert_eq!(v1, None);
         assert_eq!(v2, Some(&mut 20));


### PR DESCRIPTION
The implemention  of new HashMap api added in Rust std library in Rust 1.86.0 .
Related:
- #257 