### PR TITLE
Set MSRV to `Rust 1.79`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@
 name = "micromap"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.79"
 repository = "https://github.com/yegor256/micromap"
 description = "The fastest alternative to HashMap, for maps smaller than 20 keys"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ For the maps of just a few keys, the gain was enormous.
 
 ## How to Contribute
 
-First, install [Rust](https://www.rust-lang.org/tools/install), update to the last version by `rustup update stable`, and then:
+First, install [Rust](https://www.rust-lang.org/tools/install), update to the
+last version by `rustup update stable`, and then:
 
 ```bash
 cargo test -vv

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 [![cargo](https://github.com/yegor256/micromap/actions/workflows/cargo.yml/badge.svg)](https://github.com/yegor256/micromap/actions/workflows/cargo.yml)
 [![crates.io](https://img.shields.io/crates/v/micromap.svg)](https://crates.io/crates/micromap)
+[![docs.rs](https://img.shields.io/docsrs/micromap)](https://docs.rs/micromap/latest/micromap/)
+[![MSRV](https://img.shields.io/badge/MSRV-1.79-ffc832)](https://blog.rust-lang.org/2024/06/13/Rust-1.79.0.html)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/yegor256/micromap/blob/master/LICENSE.txt)
 [![codecov](https://codecov.io/gh/yegor256/micromap/branch/master/graph/badge.svg)](https://codecov.io/gh/yegor256/micromap)
 [![Hits-of-Code](https://hitsofcode.com/github/yegor256/micromap)](https://hitsofcode.com/view/github/yegor256/micromap)
-[![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/yegor256/micromap/blob/master/LICENSE.txt)
-[![docs.rs](https://img.shields.io/docsrs/micromap)](https://docs.rs/micromap/latest/micromap/)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fyegor256%2Fmicromap.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fyegor256%2Fmicromap?ref=badge_shield&issueType=license)
 
 A much faster alternative of
@@ -95,9 +96,15 @@ As you see, the highest performance gain was achieved for the maps that
 were smaller than ten keys.
 For the maps of just a few keys, the gain was enormous.
 
+## MSRV (Minimum Supported Rust Version)
+
+**`Rust 1.79`**
+
+(Enabling some features will affect MSRV, the documentation will note it.)
+
 ## How to Contribute
 
-First, install [Rust](https://www.rust-lang.org/tools/install) and then:
+First, install [Rust](https://www.rust-lang.org/tools/install), update to the last version by `rustup update stable`, and then:
 
 ```bash
 cargo test -vv


### PR DESCRIPTION
Add the manifest new field [`rust-version`](https://doc.rust-lang.org/cargo/reference/rust-version.html).
Now we have the new `MSRV 1.79` badge(pretty nice) in Readme header! 

For information on how MSRV is determined, check the issue:
- https://github.com/yegor256/micromap/issues/265

And after we settled on that, I tried to check it with [cargo-msrv](https://github.com/foresterre/cargo-msrv) and surprisingly got **exactly the same** results.

![cargo-msrv micromap MSRV  屏幕截图 2025-04-11 131129](https://github.com/user-attachments/assets/1f28a20d-6349-4ce0-b4f1-7e51a0a96c7e)

So I thought `Rust 1.79` would be a good choice.