### PR TITLE
Add `sub()` api for Set.

### DIFF
--- a/src/set/mod.rs
+++ b/src/set/mod.rs
@@ -15,6 +15,7 @@ mod iterators;
 mod methods;
 #[cfg(feature = "serde")]
 mod serialization;
+mod sub;
 mod symmetric_difference;
 mod union;
 

--- a/src/set/sub.rs
+++ b/src/set/sub.rs
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023-2025 Yegor Bugayenko
+// SPDX-FileCopyrightText: Copyright (c) 2025 owtotwo
+// SPDX-License-Identifier: MIT
+
+use core::ops::Sub;
+
+use super::Set;
+
+impl<T, const N: usize, const M: usize> Sub<&Set<T, M>> for &Set<T, N>
+where
+    T: PartialEq + Clone,
+{
+    type Output = Set<T, N>;
+
+    /// Returns the difference of `self` and `rhs` as a new `Set<T, N>`.
+    /// The capacity of return set is same as `Self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use micromap::Set;
+    ///
+    /// let a = Set::from([0, 1, 2, 3, 4]);
+    /// let b = Set::from([1, 3, 4, 5]);
+    /// let set = &a - &b;
+    /// let expected = Set::from([0, 2]);
+    ///
+    /// assert_eq!(result, expected);
+    /// ```
+    fn sub(self, rhs: &Set<T, M>) -> Set<T, N> {
+        self.difference(rhs).cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::Set;
+
+    #[test]
+    fn test_sub_with_non_overlapping_sets() {
+        let a = Set::from([1, 2, 3]);
+        let b = Set::from([4, 5, 6]);
+        let result = &a - &b;
+        let expected = [1, 2, 3];
+        let mut i = 0;
+        for x in &result {
+            assert!(expected.contains(x));
+            i += 1;
+        }
+        assert_eq!(i, expected.len());
+    }
+
+    #[test]
+    fn test_sub_with_overlapping_sets() {
+        let a = Set::from([1, 2, 3, 4]);
+        let b = Set::from([3, 4, 5]);
+        let result = &a - &b;
+        let expected = [1, 2];
+        assert_eq!(
+            expected.len(),
+            result.iter().fold(0, |acc, x| {
+                assert!(expected.contains(x));
+                acc + 1
+            })
+        );
+    }
+
+    #[test]
+    fn test_sub_with_empty_rhs() {
+        let a = Set::from([1, 2, 3]);
+        let b = Set::from([]);
+        let result = &a - &b;
+        let expected = Set::from([1, 2, 3, 3, 2, 1]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_sub_with_empty_lhs() {
+        let a = Set::from([]);
+        let b = Set::from([1, 2, 3]);
+        let result = &a - &b;
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_sub_with_identical_sets() {
+        let a = Set::from([1, 2, 3]);
+        let b = Set::from([1, 2, 3]);
+        let result = &a - &b;
+        assert!(result.is_empty());
+    }
+}

--- a/src/set/sub.rs
+++ b/src/set/sub.rs
@@ -25,7 +25,7 @@ where
     /// let set = &a - &b;
     /// let expected = Set::from([0, 2]);
     ///
-    /// assert_eq!(result, expected);
+    /// assert_eq!(set, expected);
     /// ```
     fn sub(self, rhs: &Set<T, M>) -> Set<T, N> {
         self.difference(rhs).cloned().collect()


### PR DESCRIPTION
The operator overload for Set's subtraction by [`Sub`](https://doc.rust-lang.org/1.86.0/std/collections/struct.HashSet.html#impl-Sub%3C%26HashSet%3CT,+S%3E%3E-for-%26HashSet%3CT,+S%3E) trait.