### PR TITLE
Fixed the incorrect behavior of `insert()`, added `insert_key_value()` api. Updated a lot of more detailed documents.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,12 @@ default = []
 std = []
 serde = ["dep:serde", "dep:bincode"]
 
+# Ref: https://users.rust-lang.org/t/how-to-document-optional-features-in-api-docs/64577/3
+[package.metadata.docs.rs]
+all-features = true
+rust-toolchain = "nightly"
+rustdoc-args = ["--cfg", "docsrs"]
+
 [[bench]]
 name = "bench"
 harness = false

--- a/README.md
+++ b/README.md
@@ -126,13 +126,13 @@ cargo bench --bench bench
 
 If you modified the comment docs, run this to check:
 
-- Linux:
+* Linux:
 
     ```bash
     RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps
     ```
 
-- Windows(PowerShell):
+* Windows(PowerShell):
 
     ```PowerShell
     $env:RUSTDOCFLAGS="--cfg docsrs"; cargo +nightly doc --all-features --no-deps --open; Remove-Item Env:\RUSTDOCFLAGS

--- a/README.md
+++ b/README.md
@@ -126,9 +126,17 @@ cargo bench --bench bench
 
 If you modified the comment docs, run this to check:
 
-```bash
-cargo doc --all-features --no-deps --open
-```
+- Linux:
+
+    ```bash
+    RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps
+    ```
+
+- Windows(PowerShell):
+
+    ```PowerShell
+    $env:RUSTDOCFLAGS="--cfg docsrs"; cargo +nightly doc --all-features --no-deps --open; Remove-Item Env:\RUSTDOCFLAGS
+    ```
 
 Then, after the changes you make, run it again. Compare the results.
 If your changes

--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ Also, before you start making changes, run benchmarks:
 cargo bench --bench bench
 ```
 
+If you modified the comment docs, run this to check:
+
+```bash
+cargo doc --all-features --no-deps --open
+```
+
 Then, after the changes you make, run it again. Compare the results.
 If your changes
 degrade performance, think twice before submitting a pull request.

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -3,13 +3,20 @@
 
 use crate::Map;
 
-impl<K: Clone, V: Clone, const N: usize> Clone for Map<K, V, N> {
+impl<K, V, const N: usize> Clone for Map<K, V, N>
+where
+    K: Clone,
+    V: Clone,
+{
     fn clone(&self) -> Self {
-        let mut m: Self = Self::new();
-        for i in 0..self.len {
-            unsafe { m.item_write(i, self.item_ref(i).clone()) };
-        }
+        let mut m = Self::new();
         m.len = self.len;
+        m.pairs
+            .iter_mut()
+            .zip(self.pairs[..self.len].iter())
+            .for_each(|(dst, src)| unsafe {
+                dst.write(src.assume_init_ref().clone());
+            });
         m
     }
 }

--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -35,6 +35,29 @@ impl<K, V, const N: usize> Map<K, V, N> {
             pairs: [const { MaybeUninit::uninit() }; N],
         }
     }
+    /// Creates an empty [Map] with fixed capacity.
+    ///
+    /// The map will be able to hold at most `capacity` elements. And
+    /// the argument `capacity` should be always equal to the generic
+    /// constant `N`.
+    ///
+    /// # Panics
+    ///
+    /// If `capacity` is not equal to `N`, the function will panic.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use micromap::Map;
+    /// let mut map: Map<&str, i32, 10> = Map::with_capacity(10);
+    /// ```
+    #[deprecated(note = "Please use `new()` instead.")]
+    #[inline]
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        assert!(capacity == N, "capacity must be equal to N");
+        Self::new()
+    }
 }
 
 impl<K, V, const N: usize> Drop for Map<K, V, N> {

--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -5,7 +5,7 @@ use crate::Map;
 use core::mem::MaybeUninit;
 
 impl<K, V, const N: usize> Default for Map<K, V, N> {
-    /// Make a default empty [`Map`].
+    /// Creates a empty [Map] like [`Map::new`].
     #[inline]
     fn default() -> Self {
         Self::new()
@@ -13,13 +13,22 @@ impl<K, V, const N: usize> Default for Map<K, V, N> {
 }
 
 impl<K, V, const N: usize> Map<K, V, N> {
-    /// Make it.
+    /// Creates an empty (len) Linear Map with capacity `N`.
     ///
-    /// The size of the map is defined by the generic argument. For example,
-    /// this is how you make a map of four key-values pairs:
+    /// The linear map is initially created with a capacity of `N`, so it
+    /// will immediately occupy memory on the stack (no allocation on heap).
+    ///
+    /// After creation, capacity will not change, which is the max len of
+    /// the map.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use micromap::Map;
+    /// let mut map: Map<&str, i32, 20> = Map::new();
+    /// ```
     #[inline]
     #[must_use]
-    #[allow(clippy::uninit_assumed_init)]
     pub const fn new() -> Self {
         Self {
             len: 0,

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -2,10 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 use crate::Map;
-use core::fmt::{self, Debug, Formatter};
+use core::fmt;
 
-impl<K: Debug, V: Debug, const N: usize> Debug for Map<K, V, N> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl<K, V, const N: usize> fmt::Debug for Map<K, V, N>
+where
+    K: fmt::Debug,
+    V: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_map().entries(self.iter()).finish()
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -2,21 +2,20 @@
 // SPDX-License-Identifier: MIT
 
 use crate::Map;
-use core::fmt::{self, Display, Formatter, Write};
+use core::fmt;
+use core::fmt::Write;
 
-impl<K: Display, V: Display, const N: usize> Display for Map<K, V, N> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let mut first = true;
+impl<K, V, const N: usize> fmt::Display for Map<K, V, N>
+where
+    K: fmt::Display,
+    V: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_char('{')?;
-        for (k, v) in self {
-            if first {
-                first = false;
-            } else {
-                f.write_str(", ")?;
-            }
-            k.fmt(f)?;
-            f.write_str(": ")?;
-            v.fmt(f)?;
+        let mut it = self.iter();
+        if let Some((k, v)) = it.next() {
+            write!(f, "{k}: {v}")?;
+            it.try_for_each(|(k, v)| write!(f, ", {k}: {v}"))?;
         }
         f.write_char('}')?;
         Ok(())
@@ -27,6 +26,19 @@ impl<K: Display, V: Display, const N: usize> Display for Map<K, V, N> {
 mod tests {
 
     use super::*;
+
+    #[test]
+    fn displays_empty_map() {
+        let m: Map<String, i32, 0> = Map::new();
+        assert_eq!(r#"{}"#, format!("{}", m));
+    }
+
+    #[test]
+    fn displays_one_item_map() {
+        let mut m: Map<u32, bool, 1> = Map::new();
+        m.insert(42, true);
+        assert_eq!(r#"{42: true}"#, format!("{}", m));
+    }
 
     #[test]
     fn displays_map() {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -109,7 +109,7 @@ impl<K, V, const N: usize> VacantEntry<'_, K, V, N> {
 
 impl<'a, K: PartialEq, V, const N: usize> VacantEntry<'a, K, V, N> {
     pub fn insert(self, value: V) -> &'a mut V {
-        let (index, _) = self.table.insert_i(self.key, value);
+        let (index, _) = self.table.insert_ii(self.key, value, false);
         unsafe { self.table.value_mut(index) }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
 #![warn(rust_2018_idioms)]
 // #![warn(missing_docs)]
-#![cfg_attr(docsrs, warn(rustdoc::missing_doc_code_examples))]
+#![cfg_attr(docsrs, feature(rustdoc_missing_doc_code_examples))]
 #![warn(rustdoc::missing_crate_level_docs)]
 #![doc(test(attr(warn(unused))))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,12 +26,16 @@
 //! will have exactly ten elements. An attempt to add an 11th element will lead
 //! to a panic.
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(all(not(feature = "std"), not(doc), not(test)), no_std)]
 #![doc(html_root_url = "https://docs.rs/micromap/0.0.0")]
 #![deny(warnings)]
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
 #![warn(rust_2018_idioms)]
-#![allow(clippy::multiple_crate_versions)]
+// #![warn(missing_docs)]
+#![cfg_attr(docsrs, warn(rustdoc::missing_doc_code_examples))]
+#![warn(rustdoc::missing_crate_level_docs)]
+#![doc(test(attr(warn(unused))))]
 
 mod clone;
 mod ctors;
@@ -46,6 +50,7 @@ mod iterators;
 mod keys;
 mod map;
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 mod serialization;
 mod set;
 mod values;

--- a/src/map.rs
+++ b/src/map.rs
@@ -37,7 +37,9 @@ impl<K, V, const N: usize> Map<K, V, N> {
         drain
     }
 
-    /// Remove all pairs from it, but keep the space intact for future use.
+    /// Clears the map, removing all key-value pairs (drop them). But keeps the
+    /// memory that was occupied when creating the [Map], that is, will not
+    /// release any memory usage.
     #[inline]
     pub fn clear(&mut self) {
         for i in 0..self.len {

--- a/src/set/methods.rs
+++ b/src/set/methods.rs
@@ -201,7 +201,7 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
     /// ```
     #[inline]
     pub fn replace(&mut self, value: T) -> Option<T> {
-        let (_, existing_pair) = self.map.insert_i(value, ());
+        let (_, existing_pair) = self.map.insert_ii(value, (), true);
         existing_pair.map(|(k, ())| k)
     }
 }

--- a/src/set/mod.rs
+++ b/src/set/mod.rs
@@ -14,6 +14,7 @@ mod intersection;
 mod iterators;
 mod methods;
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 mod serialization;
 mod sub;
 mod symmetric_difference;


### PR DESCRIPTION
Because `rustdoc` is used to generate documents in Rust, and many features are unstable. For example, to clearly mark that a method needs to enable a certain feature, the unstable feature of `rustdoc` will be used (such as `doc_cfg`). Therefore, the nightly version is used when generating documents. This is the practice used by most complete Rust projects.

Example from Rust offical project: https://github.com/rust-lang/regex/blob/1a069b9232c607b34c4937122361aa075ef573fa/Cargo.toml#L229-L240

And the behavior of `insert()`, which will only update the value, the key is not included.
(Check it: https://doc.rust-lang.org/1.86.0/std/collections/index.html#insert-and-complex-keys)

In order to be compatible with the official `insert()` behavior and at the same time we need to update the key, we provide a new api `insert_key_value()`, which is like the relationship between `get()` and `get_key_value()`. (Also some new unit tests added related to this.)

It also includes the improvement and supplement of many comment documents, as well as doc test examples.

