### PR TITLE
Some CI improvements, remove unnecessary content, add `docs` ci to .workflow .

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -17,15 +17,11 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 17
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - run: cargo test --all-features -vv -- --nocapture
-      - run: cargo test --release --all-features -vv -- --nocapture
+      - run: cargo test --all-features -- --show-output
+      - run: cargo test --release --all-features -- --show-output
       - run: cargo fmt --check
       - run: cargo doc --no-deps
       - run: cargo clippy -- --no-deps

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           toolchain: nightly
       - run: cargo +nightly test --doc --all-features -- --show-output
-      - run: cargo +nightly doc --all-features --no-deps      
+      - run: cargo +nightly doc --all-features --no-deps

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,5 +19,5 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
-      - run: cargo +nightly test --doc --all-features -- --nocapture
+      - run: cargo +nightly test --doc --all-features -- --show-output
       - run: cargo +nightly doc --all-features --no-deps      

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2025 Yegor Bugayenko
+# SPDX-FileCopyrightText: Copyright (c) 2025 owtotwo
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-name: cargo
+name: docs
 'on':
   push:
   pull_request:
@@ -17,15 +18,10 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 17
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
-      - run: cargo test --all-features -vv -- --nocapture
-      - run: cargo test --release --all-features -vv -- --nocapture
-      - run: cargo fmt --check
-      - run: cargo doc --no-deps
-      - run: cargo clippy -- --no-deps
+          toolchain: nightly
+      - run: cargo test --doc --all-features -- --nocapture
+      - run: cargo doc --all-features --no-deps
+        env:
+          RUSTDOCFLAGS: '--cfg docsrs'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,9 +7,6 @@ name: docs
 'on':
   push:
   pull_request:
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   build:
     timeout-minutes: 15

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
-      - run: cargo test --doc --all-features -- --nocapture
-      - run: cargo doc --all-features --no-deps
+      - run: cargo +nightly test --doc --all-features -- --nocapture
+      - run: cargo +nightly doc --all-features --no-deps
         env:
           RUSTDOCFLAGS: '--cfg docsrs'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,12 +13,11 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       CARGO_TERM_COLOR: always
+      RUSTDOCFLAGS: '--cfg docsrs'
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
       - run: cargo +nightly test --doc --all-features -- --nocapture
-      - run: cargo +nightly doc --all-features --no-deps
-        env:
-          RUSTDOCFLAGS: '--cfg docsrs'
+      - run: cargo +nightly doc --all-features --no-deps      

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -11,6 +11,8 @@ jobs:
   run-examples:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
+    env:
+      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -7,6 +7,7 @@ name: markdown-lint
   push:
     branches:
       - master
+      - dev
   pull_request:
     branches:
       - master

--- a/.github/workflows/tarpaulin.yml
+++ b/.github/workflows/tarpaulin.yml
@@ -7,6 +7,7 @@ name: tarpaulin
   push:
     branches:
       - master
+      - dev
 jobs:
   tarpaulin:
     timeout-minutes: 15

--- a/.github/workflows/tarpaulin.yml
+++ b/.github/workflows/tarpaulin.yml
@@ -20,7 +20,7 @@ jobs:
       - run: |-
           wget https://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.24_amd64.deb && \
           sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.24_amd64.deb
-      - uses: actions-rs/tarpaulin@v0.1
+      - uses: actions-rs/tarpaulin@v0.1.0
         with:
           version: '0.22.0' # the last version that supports tarpaulin@v0.1, which is no longer maintained.
           args: '--all-features --exclude-files src/lib.rs -- --test-threads 1'

--- a/.github/workflows/tarpaulin.yml
+++ b/.github/workflows/tarpaulin.yml
@@ -21,7 +21,7 @@ jobs:
       - run: |-
           wget https://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.24_amd64.deb && \
           sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.24_amd64.deb
-      - uses: actions-rs/tarpaulin@v0.1.0
+      - uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.22.0' # the last version that supports tarpaulin@v0.1, which is no longer maintained.
           args: '--all-features --exclude-files src/lib.rs -- --test-threads 1'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,15 +26,17 @@
 //! will have exactly ten elements. An attempt to add an 11th element will lead
 //! to a panic.
 
-#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(all(not(feature = "std"), not(doc), not(test)), no_std)]
 #![doc(html_root_url = "https://docs.rs/micromap/0.0.0")]
 #![deny(warnings)]
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
 #![warn(rust_2018_idioms)]
-// #![warn(missing_docs)]
+// About the docs
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, feature(rustdoc_missing_doc_code_examples))]
 #![warn(rustdoc::missing_crate_level_docs)]
+// Our Goal, uncomment these!
+// #![warn(missing_docs)]
 // #![doc(test(attr(deny(unused))))]
 #![doc(test(attr(warn(unused))))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 // #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(rustdoc_missing_doc_code_examples))]
 #![warn(rustdoc::missing_crate_level_docs)]
+// #![doc(test(attr(deny(unused))))]
 #![doc(test(attr(warn(unused))))]
 
 mod clone;


### PR DESCRIPTION
- Because GitHub Aciton supports _term color_, we can keep the output color (if no color is needed, just filter it).
- Because the Rust compiler's error reporting is very precise, there is almost no need to use `-vv`, which will wrap the error in a pile of useless output when building dependencies, so we don't need it very much. (Also this makes CI run much faster)
- The `--nocapture` is an old option, there is a newer and better replacement `--show-output`, we use it instead.