### PR TITLE
Decouple Map method APIs in `map.rs`. Add docs and impl the missing trait for `keys()` and `values()` series API.

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,8 +1,53 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023-2025 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
-use crate::{Entry, OccupiedEntry, VacantEntry};
+use super::Map;
 use core::mem;
+
+impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
+    pub fn entry(&mut self, k: K) -> Entry<'_, K, V, N> {
+        for i in 0..self.len {
+            let p = unsafe { self.item_ref(i) };
+            if p.0 == k {
+                return Entry::Occupied(OccupiedEntry {
+                    index: i,
+                    table: self,
+                });
+            }
+        }
+        Entry::Vacant(VacantEntry {
+            key: k,
+            table: self,
+        })
+    }
+}
+
+/// A view into a single entry in a map, which may either be vacant or occupied.
+///
+/// This `enum` is constructed from the [`entry`] method on [`Map`].
+///
+/// [`entry`]: Map::entry
+pub enum Entry<'a, K, V, const N: usize> {
+    /// An occupied entry.
+    Occupied(OccupiedEntry<'a, K, V, N>),
+
+    /// A vacant entry.
+    Vacant(VacantEntry<'a, K, V, N>),
+}
+
+/// A view into an occupied entry in a `Map`.
+/// It is part of the [`Entry`] enum.
+pub struct OccupiedEntry<'a, K, V, const N: usize> {
+    index: usize,
+    table: &'a mut Map<K, V, N>,
+}
+
+/// A view into a vacant entry in a `Map`.
+/// It is part of the [`Entry`] enum.
+pub struct VacantEntry<'a, K, V, const N: usize> {
+    key: K,
+    table: &'a mut Map<K, V, N>,
+}
 
 impl<K, V, const N: usize> Entry<'_, K, V, N> {
     pub fn key(&self) -> &K {

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -121,7 +121,7 @@ pub struct IterMut<'a, K, V> {
 /// ```
 #[repr(transparent)]
 pub struct IntoIter<K, V, const N: usize> {
-    map: Map<K, V, N>,
+    pub(super) map: Map<K, V, N>,
 }
 
 /// Utility function for implementing Debug trait for iterators (whose inner is a slice).

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -99,7 +99,7 @@ pub struct Iter<'a, K, V> {
 /// ```
 #[repr(transparent)]
 pub struct IterMut<'a, K, V> {
-    iter: core::slice::IterMut<'a, MaybeUninit<(K, V)>>,
+    pub(super) iter: core::slice::IterMut<'a, MaybeUninit<(K, V)>>,
 }
 
 /// An owning iterator over the entries of a `Map`.

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023-2025 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
-use crate::{IntoKeys, Keys, Map};
+use super::Map;
+use super::{IntoIter, Iter};
 use core::iter::FusedIterator;
 
 impl<K, V, const N: usize> Map<K, V, N> {
@@ -18,6 +19,18 @@ impl<K, V, const N: usize> Map<K, V, N> {
             iter: self.into_iter(),
         }
     }
+}
+
+/// A read-only iterator over the keys of the [`Map`].
+#[repr(transparent)]
+pub struct Keys<'a, K, V> {
+    iter: Iter<'a, K, V>,
+}
+
+/// Consuming iterator over the keys of the [`Map`].
+#[repr(transparent)]
+pub struct IntoKeys<K, V, const N: usize> {
+    iter: IntoIter<K, V, N>,
 }
 
 impl<K, V> Clone for Keys<'_, K, V> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,14 @@ mod serialization;
 mod set;
 mod values;
 
+// re-export
 pub use drain::Drain;
+pub use entry::{Entry, OccupiedEntry, VacantEntry};
 pub use iterators::{IntoIter, Iter, IterMut};
+pub use keys::{IntoKeys, Keys};
+pub use values::{IntoValues, Values, ValuesMut};
+
+// re-export Set
 pub use set::{Set, SetDrain, SetIntoIter, SetIter};
 
 use core::mem::MaybeUninit;
@@ -94,61 +100,4 @@ pub struct Map<K, V, const N: usize> {
     len: usize,
     /// The fixed-size array of key-value pairs.
     pairs: [MaybeUninit<(K, V)>; N],
-}
-
-/// An iterator over the values of the [`Map`].
-#[repr(transparent)]
-pub struct Values<'a, K, V> {
-    iter: Iter<'a, K, V>,
-}
-
-/// Mutable iterator over the values of the [`Map`].
-#[repr(transparent)]
-pub struct ValuesMut<'a, K, V> {
-    iter: IterMut<'a, K, V>,
-}
-
-/// Consuming iterator over the values of the [`Map`].
-#[repr(transparent)]
-pub struct IntoValues<K, V, const N: usize> {
-    iter: IntoIter<K, V, N>,
-}
-
-/// A read-only iterator over the keys of the [`Map`].
-#[repr(transparent)]
-pub struct Keys<'a, K, V> {
-    iter: Iter<'a, K, V>,
-}
-
-/// Consuming iterator over the keys of the [`Map`].
-#[repr(transparent)]
-pub struct IntoKeys<K, V, const N: usize> {
-    iter: IntoIter<K, V, N>,
-}
-
-/// A view into a single entry in a map, which may either be vacant or occupied.
-///
-/// This `enum` is constructed from the [`entry`] method on [`Map`].
-///
-/// [`entry`]: Map::entry
-pub enum Entry<'a, K, V, const N: usize> {
-    /// An occupied entry.
-    Occupied(OccupiedEntry<'a, K, V, N>),
-
-    /// A vacant entry.
-    Vacant(VacantEntry<'a, K, V, N>),
-}
-
-/// A view into an occupied entry in a `Map`.
-/// It is part of the [`Entry`] enum.
-pub struct OccupiedEntry<'a, K, V, const N: usize> {
-    index: usize,
-    table: &'a mut Map<K, V, N>,
-}
-
-/// A view into a vacant entry in a `Map`.
-/// It is part of the [`Entry`] enum.
-pub struct VacantEntry<'a, K, V, const N: usize> {
-    key: K,
-    table: &'a mut Map<K, V, N>,
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023-2025 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
-use crate::{Entry, Map, OccupiedEntry, VacantEntry};
+use crate::Map;
 use core::borrow::Borrow;
 
 impl<K, V, const N: usize> Map<K, V, N> {
@@ -450,22 +450,6 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
             }
         }
         None
-    }
-
-    pub fn entry(&mut self, k: K) -> Entry<'_, K, V, N> {
-        for i in 0..self.len {
-            let p = unsafe { self.item_ref(i) };
-            if p.0 == k {
-                return Entry::Occupied(OccupiedEntry {
-                    index: i,
-                    table: self,
-                });
-            }
-        }
-        Entry::Vacant(VacantEntry {
-            key: k,
-            table: self,
-        })
     }
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -208,10 +208,28 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
 
     /// Attempt to insert a pair into the map. (no panic)
     ///
-    /// - If the key existed, we update the pair, return `Some(old_value)`
+    /// - If the key existed, we update the pair, return `Some(Some(old_value))`
     /// - If the key does not exist and the map has empty slot, we insert into that slot
     ///   and return `Some(None)`.
     /// - If the key does not exist and the map is full already, return `None`.
+    ///
+    /// # Examples
+    /// ```
+    /// use micromap::Map;
+    /// let mut m: Map<_, _, 3> = Map::new();
+    /// // For `Some(None)`, `Some(_)` indicates that the insertion was successful, `None`
+    /// // means that the inserted key was not in map, that is, insert instead of update.
+    /// assert_eq!(m.checked_insert(1, "a"), Some(None));
+    /// assert_eq!(m.checked_insert(1, "A"), Some(Some("a")));
+    /// assert_eq!(m.checked_insert(2, "b"), Some(None));
+    /// assert_eq!(m.checked_insert(3, "c"), Some(None));
+    /// assert_eq!(m.len(), m.capacity());
+    /// // map is full now.
+    /// assert_eq!(m.checked_insert(2, "B"), Some(Some("b")));
+    /// // This insertion will cause capacity overflow, so no insertion is performed
+    /// // and `None` is returned.
+    /// assert_eq!(m.checked_insert(4, "d"), None);
+    /// ```
     #[inline]
     pub fn checked_insert(&mut self, k: K, v: V) -> Option<Option<V>> {
         if self.len < N {

--- a/src/map.rs
+++ b/src/map.rs
@@ -339,6 +339,37 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     }
 
     /// Returns the key-value pair corresponding to the supplied key.
+    ///
+    /// The key may be any borrowed form of the map’s key type, but
+    /// [`PartialEq`] on the borrowed form must match those for the key
+    /// type.
+    ///
+    /// # Examples
+    /// ```
+    /// use micromap::Map;
+    /// // Only the first element in the tuple is considered when
+    /// // determining whether two `S` are equal.
+    /// #[derive(Clone, Copy, Debug)]
+    /// struct S {
+    ///     id: u32,
+    ///     name: &'static str, // ignored by equality and hashing operations
+    /// }
+    /// impl PartialEq for S {
+    ///     fn eq(&self, other: &S) -> bool {
+    ///         self.id == other.id
+    ///     }
+    /// }
+    /// // Note the impact of `.name` in code.
+    /// let j_a = S { id: 1, name: "Jessica" };
+    /// let j_b = S { id: 1, name: "Jess" };
+    /// let p = S { id: 2, name: "Paul" };
+    /// assert_ne!(j_a.name, j_b.name);
+    /// assert_eq!(j_a, j_b);
+    /// let mut m: Map<_, _, 3> = Map::new();
+    /// m.insert(j_a, "Paris");
+    /// assert_eq!(m.get_key_value(&j_a), Some((&j_a, &"Paris")));
+    /// assert_eq!(m.get_key_value(&j_b), Some((&j_a, &"Paris"))); // the notable case
+    /// assert_eq!(m.get_key_value(&p), None);
     #[inline]
     pub fn get_key_value<Q>(&self, k: &Q) -> Option<(&K, &V)>
     where

--- a/src/map.rs
+++ b/src/map.rs
@@ -10,6 +10,16 @@ impl<K, V, const N: usize> Map<K, V, N> {
     ///
     /// Note that the number of the inserted pairs (with difference keys)
     /// should not exceed this value.
+    ///
+    /// # Examples
+    /// ```
+    /// use micromap::Map;
+    /// const N: usize = 3;
+    /// let mut m = Map::<_, _, N>::new();
+    /// m.insert(1, "a");
+    /// assert_eq!(m.capacity(), N);
+    /// assert_eq!(m.len(), 1);
+    /// ```
     #[inline]
     #[must_use]
     pub const fn capacity(&self) -> usize {
@@ -19,13 +29,12 @@ impl<K, V, const N: usize> Map<K, V, N> {
     /// Returns true if the map contains no key-value pair.
     ///
     /// # Examples
-    ///
     /// ```
     /// use micromap::Map;
-    /// let mut a = Map::<_, _, 3>::new();
-    /// assert!(a.is_empty());
-    /// a.insert(1, "a");
-    /// assert!(!a.is_empty());
+    /// let mut m = Map::<_, _, 3>::new();
+    /// assert!(m.is_empty());
+    /// m.insert(1, "a");
+    /// assert!(!m.is_empty());
     /// ```
     #[inline]
     #[must_use]
@@ -38,10 +47,10 @@ impl<K, V, const N: usize> Map<K, V, N> {
     /// # Examples
     /// ```
     /// use micromap::Map;
-    /// let mut a = Map::<_, _, 3>::new();
-    /// assert_eq!(a.len(), 0);
-    /// a.insert(1, "a");
-    /// assert_eq!(a.len(), 1);
+    /// let mut m = Map::<_, _, 3>::new();
+    /// assert_eq!(m.len(), 0);
+    /// m.insert(1, "a");
+    /// assert_eq!(m.len(), 1);
     /// ```
     #[inline]
     #[must_use]
@@ -53,6 +62,15 @@ impl<K, V, const N: usize> Map<K, V, N> {
     ///
     /// But keeps the memory that was occupied when creating the [Map], that is, will not
     /// release any memory usage.
+    ///
+    /// # Examples
+    /// ```
+    /// use micromap::Map;
+    /// let mut m = Map::<_, _, 3>::new();
+    /// m.insert(1, "a");
+    /// m.clear();
+    /// assert!(m.is_empty());
+    /// ```
     #[inline]
     pub fn clear(&mut self) {
         for i in 0..self.len {
@@ -62,6 +80,21 @@ impl<K, V, const N: usize> Map<K, V, N> {
     }
 
     /// Retains only the elements specified by the predicate.
+    ///
+    /// In other words, remove all pairs `(k, v)` for which `f(&k, &mut v)`
+    /// returns false. The elements are visited in unsorted (and unspecified)
+    /// order.
+    ///
+    /// # Examples
+    /// ```
+    /// use micromap::Map;
+    /// let mut map: Map<_, _, 8> = Map::from_iter((0..8).map(|x| (x, x*10)));
+    /// map.retain(|&k, _| k % 2 == 0);
+    /// assert_eq!(map.len(), 4);
+    /// ```
+    ///
+    /// # Performance
+    /// In the current implementation, this operation takes O(len) time.
     #[inline]
     pub fn retain<F: FnMut(&K, &mut V) -> bool>(&mut self, mut f: F) {
         let mut i = 0;

--- a/src/map.rs
+++ b/src/map.rs
@@ -597,6 +597,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
 mod internal {
     use crate::Map;
 
+    /// The unsafe wrapper operations for the `&[MaybeUninit]` array in [`Map`] struct.
     impl<K, V, const N: usize> Map<K, V, N> {
         /// Internal function to get mutable access via reference to the value in the internal array.
         #[inline]
@@ -622,19 +623,19 @@ mod internal {
             self.pairs.get_unchecked(i).assume_init_read()
         }
 
-        /// Internal function to get access to the element in the internal array.
+        /// Internal function to get access to the element in the internal array and drop it.
         #[inline]
         pub(crate) unsafe fn item_drop(&mut self, i: usize) {
             self.pairs.get_unchecked_mut(i).assume_init_drop();
         }
 
-        /// Internal function to get access to the element in the internal array.
+        /// Internal function to write key and value to the element in the internal array.
         #[inline]
         pub(crate) unsafe fn item_write(&mut self, i: usize, val: (K, V)) {
             self.pairs.get_unchecked_mut(i).write(val);
         }
 
-        /// Remove an index (by swapping the last one here and reducing the length)
+        /// Remove by index and drop it (by swapping the last one here and reducing the length).
         #[inline]
         pub(crate) unsafe fn remove_index_drop(&mut self, i: usize) {
             self.item_drop(i);
@@ -645,7 +646,7 @@ mod internal {
             }
         }
 
-        /// Remove an index (by swapping the last one here and reducing the length)
+        /// Remove by index and return it (by swapping the last one here and reducing the length).
         #[inline]
         pub(crate) unsafe fn remove_index_read(&mut self, i: usize) -> (K, V) {
             let result = self.item_read(i);
@@ -658,6 +659,7 @@ mod internal {
         }
     }
 
+    /// The insert core logic for the [`Map`] struct.
     impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
         /// The core insert logic, which is used for `insert_unchecked()`, as it will
         /// disable the bound check (`debug_assert!`) in `release` mode.

--- a/src/set/methods.rs
+++ b/src/set/methods.rs
@@ -52,7 +52,7 @@ impl<T, const N: usize> Set<T, N> {
 }
 
 impl<T: PartialEq, const N: usize> Set<T, N> {
-    /// Returns true if the set contains a value.
+    /// Returns `true` if the set contains a value.
     #[inline]
     #[must_use]
     pub fn contains<Q: PartialEq + ?Sized>(&self, k: &Q) -> bool
@@ -75,8 +75,8 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
     ///
     /// Returns whether the value was newly inserted. That is:
     ///
-    /// If the set did not previously contain this value, true is returned.
-    /// If the set already contained this value, false is returned, and the set is not
+    /// If the set did not previously contain this value, `true` is returned.
+    /// If the set already contained this value, `false` is returned, and the set is not
     /// modified: original value is not replaced, and the value passed as argument is dropped.
     ///
     /// # Panics

--- a/src/values.rs
+++ b/src/values.rs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023-2025 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
-use crate::{IntoValues, Map, Values, ValuesMut};
+use super::{IntoIter, Iter, IterMut};
+use crate::Map;
 use core::iter::FusedIterator;
 
 impl<K, V, const N: usize> Map<K, V, N> {
@@ -26,6 +27,24 @@ impl<K, V, const N: usize> Map<K, V, N> {
             iter: self.into_iter(),
         }
     }
+}
+
+/// An iterator over the values of the [`Map`].
+#[repr(transparent)]
+pub struct Values<'a, K, V> {
+    iter: Iter<'a, K, V>,
+}
+
+/// Mutable iterator over the values of the [`Map`].
+#[repr(transparent)]
+pub struct ValuesMut<'a, K, V> {
+    iter: IterMut<'a, K, V>,
+}
+
+/// Consuming iterator over the values of the [`Map`].
+#[repr(transparent)]
+pub struct IntoValues<K, V, const N: usize> {
+    iter: IntoIter<K, V, N>,
 }
 
 impl<'a, K, V> Iterator for Values<'a, K, V> {


### PR DESCRIPTION
The next part to be improved is about `entry()`.