### PR TITLE
A lot of improvements in `Set`, mostly docs and doc-tests code.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@
 #![doc(html_root_url = "https://docs.rs/micromap/0.0.0")]
 #![deny(warnings)]
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
+// `clippy::pedantic` have false positives about the `#[must_use]` attr.
+#![allow(clippy::must_use_candidate)]
 #![warn(rust_2018_idioms)]
 // About the docs
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -37,8 +39,7 @@
 #![warn(rustdoc::missing_crate_level_docs)]
 // Our Goal, uncomment these!
 // #![warn(missing_docs)]
-// #![doc(test(attr(deny(unused))))]
-#![doc(test(attr(warn(unused))))]
+#![doc(test(attr(deny(unused))))]
 
 pub mod map;
 pub mod set;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, feature(rustdoc_missing_doc_code_examples))]
 #![warn(rustdoc::missing_crate_level_docs)]
-// Our Goal, uncomment these!
-// #![warn(missing_docs)]
+// Our Goal, uncomment these! (now we hit it.)
+#![warn(missing_docs)]
 #![doc(test(attr(deny(unused))))]
 
 pub mod map;

--- a/src/map/entry.rs
+++ b/src/map/entry.rs
@@ -97,7 +97,7 @@ impl<K, V, const N: usize> Entry<'_, K, V, N> {
     /// assert_eq!(map["poneyland"], 43);
     /// ```
     #[inline]
-    #[must_use]
+    #[allow(clippy::return_self_not_must_use)] // function has side effects (impure)
     pub fn and_modify<F>(self, f: F) -> Self
     where
         F: FnOnce(&mut V),
@@ -233,7 +233,6 @@ impl<'a, K, V, const N: usize> OccupiedEntry<'a, K, V, N> {
     /// assert_eq!(map.entry("poneyland").key(), &"poneyland");
     /// ```
     #[inline]
-    #[must_use]
     pub fn key(&self) -> &K {
         unsafe { &self.table.item_ref(self.index).0 }
     }
@@ -257,7 +256,6 @@ impl<'a, K, V, const N: usize> OccupiedEntry<'a, K, V, N> {
     /// assert_eq!(map["poneyland"], 22);
     /// ```
     #[inline]
-    #[must_use]
     pub fn into_mut(self) -> &'a mut V {
         unsafe { self.table.value_mut(self.index) }
     }
@@ -276,7 +274,6 @@ impl<'a, K, V, const N: usize> OccupiedEntry<'a, K, V, N> {
     /// }
     /// ```
     #[inline]
-    #[must_use]
     pub fn get(&self) -> &V {
         unsafe { &self.table.item_ref(self.index).1 }
     }
@@ -340,7 +337,6 @@ impl<'a, K, V, const N: usize> OccupiedEntry<'a, K, V, N> {
     /// assert_eq!(map.contains_key("poneyland"), false);
     /// ```
     #[inline]
-    #[must_use]
     pub fn remove_entry(self) -> (K, V) {
         unsafe { self.table.remove_index_read(self.index) }
     }
@@ -359,7 +355,6 @@ impl<'a, K, V, const N: usize> OccupiedEntry<'a, K, V, N> {
     /// assert_eq!(map.contains_key("poneyland"), false);
     /// ```
     #[inline]
-    #[must_use]
     pub fn remove(self) -> V {
         unsafe { self.table.remove_index_read(self.index).1 }
     }

--- a/src/map/iterators.rs
+++ b/src/map/iterators.rs
@@ -24,7 +24,6 @@ impl<K, V, const N: usize> Map<K, V, N> {
     /// In the current implementation, iterating over map takes `O(len)` time.
     /// The average complexity is `O(len/2)`.
     #[inline]
-    #[must_use]
     pub fn iter(&self) -> Iter<'_, K, V> {
         Iter {
             iter: self.pairs[..self.len].as_ref().iter(),

--- a/src/map/iterators.rs
+++ b/src/map/iterators.rs
@@ -112,7 +112,7 @@ pub struct IterMut<'a, K, V> {
 /// use micromap::Map;
 /// let map = Map::from([("a", 1)]);
 /// let _iter = map.into_iter(); // consumed map
-/// let mut map = Map::from([('b', 2), ('c', 3)]);
+/// let map = Map::from([('b', 2), ('c', 3)]);
 /// for (k, v) in map { // Implicit call as `map.into_iter()`
 ///     println!("key: {k} val: {v}");
 /// }

--- a/src/map/keys.rs
+++ b/src/map/keys.rs
@@ -13,7 +13,7 @@ impl<K, V, const N: usize> Map<K, V, N> {
     /// # Examples
     /// ```
     /// use micromap::Map;
-    /// let mut m = Map::from([("a", 1), ("b", 2), ("c", 3)]);
+    /// let m = Map::from([("a", 1), ("b", 2), ("c", 3)]);
     /// // print "a", "b", "c" in arbitrary order.
     /// for key in m.keys() {
     ///     println!("{key}");

--- a/src/map/methods.rs
+++ b/src/map/methods.rs
@@ -425,6 +425,8 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     ///     "Athenæum",
     ///     "Bodleian Library",
     /// ]) else { panic!() };
+    /// *a += 10000;
+    /// *b += 10000;
     /// // Assert values of Athenæum and Library of Congress
     /// let got = libraries.get_disjoint_mut([
     ///     "Athenæum",
@@ -433,7 +435,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     /// assert_eq!(
     ///     got,
     ///     [
-    ///         Some(&mut 1807),
+    ///         Some(&mut 11807),
     ///         Some(&mut 1800),
     ///     ],
     /// );
@@ -445,17 +447,18 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     /// assert_eq!(
     ///     got,
     ///     [
-    ///         Some(&mut 1807),
+    ///         Some(&mut 11807),
     ///         None
     ///     ]
     /// );
     /// ```
+    /// Duplicate keys will panic:
     /// ```should_panic
     /// use micromap::Map;
     /// let mut libraries: Map<String, u32, 3> = Map::new();
     /// libraries.insert("Athenæum".to_string(), 1807);
-    /// // Duplicate keys panic!
-    /// let got = libraries.get_disjoint_mut([
+    /// // panic!
+    /// let _got = libraries.get_disjoint_mut([
     ///     "Athenæum",
     ///     "Athenæum",
     /// ]);
@@ -506,6 +509,8 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     ///     "Athenæum",
     ///     "Bodleian Library",
     /// ]) }) else { panic!() };
+    /// *a += 10000;
+    /// *b += 10000;
     /// // SAFETY: The keys do not overlap.
     /// let got = unsafe { libraries.get_disjoint_unchecked_mut([
     ///     "Athenæum",
@@ -514,7 +519,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     /// assert_eq!(
     ///     got,
     ///     [
-    ///         Some(&mut 1807),
+    ///         Some(&mut 11807),
     ///         Some(&mut 1800),
     ///     ],
     /// );
@@ -524,7 +529,7 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     ///     "New York Public Library",
     /// ]) };
     /// // Missing keys result in None
-    /// assert_eq!(got, [Some(&mut 1807), None]);
+    /// assert_eq!(got, [Some(&mut 11807), None]);
     /// ```
     #[inline]
     pub unsafe fn get_disjoint_unchecked_mut<Q, const J: usize>(

--- a/src/map/methods.rs
+++ b/src/map/methods.rs
@@ -22,7 +22,6 @@ impl<K, V, const N: usize> Map<K, V, N> {
     /// assert_eq!(m.len(), 1);
     /// ```
     #[inline]
-    #[must_use]
     pub const fn capacity(&self) -> usize {
         N
     }
@@ -38,7 +37,6 @@ impl<K, V, const N: usize> Map<K, V, N> {
     /// assert!(!m.is_empty());
     /// ```
     #[inline]
-    #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.len == 0
     }
@@ -54,7 +52,6 @@ impl<K, V, const N: usize> Map<K, V, N> {
     /// assert_eq!(m.len(), 1);
     /// ```
     #[inline]
-    #[must_use]
     pub const fn len(&self) -> usize {
         self.len
     }
@@ -128,7 +125,6 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     /// assert_eq!(m.contains_key(&2), false);
     /// ```
     #[inline]
-    #[must_use]
     pub fn contains_key<Q>(&self, k: &Q) -> bool
     where
         K: Borrow<Q>,
@@ -322,7 +318,6 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     /// assert_eq!(m.get(&2), None);
     /// ```
     #[inline]
-    #[must_use]
     pub fn get<Q>(&self, k: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
@@ -350,7 +345,6 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
     /// }
     /// assert_eq!(m[&1], "b");
     /// ```
-    #[must_use]
     pub fn get_mut<Q>(&mut self, k: &Q) -> Option<&mut V>
     where
         K: Borrow<Q>,

--- a/src/map/methods.rs
+++ b/src/map/methods.rs
@@ -209,17 +209,21 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
 
     /// Attempt to insert a pair into the map. (no panic)
     ///
-    /// - If the key existed, we update the pair, return `Some(Some(old_value))`
-    /// - If the key does not exist and the map has empty slot, we insert into that slot
-    ///   and return `Some(None)`.
-    /// - If the key does not exist and the map is full already, return `None`.
+    /// - If the key does not exist and the map is full already, we can do
+    ///   nothing, so just return `None`;
+    /// - If the key does not exist and the map has empty slot, we insert
+    ///   into that slot and return `Some(None)`.
+    /// - If the key exists, whether the map is full or not, we update the
+    ///   value (exclude key), and return `Some(Some(old_value))`;
     ///
     /// # Examples
     /// ```
     /// use micromap::Map;
     /// let mut m: Map<_, _, 3> = Map::new();
     /// // For `Some(None)`, `Some(_)` indicates that the insertion was successful, `None`
-    /// // means that the inserted key was not in map, that is, insert instead of update.
+    /// // in the former means that the inserted key was not in map, that is, insert
+    /// // the key-value pair. Otherwise, when returning to the latter, only value will be
+    /// // update.
     /// assert_eq!(m.checked_insert(1, "a"), Some(None));
     /// assert_eq!(m.checked_insert(1, "A"), Some(Some("a")));
     /// assert_eq!(m.checked_insert(2, "b"), Some(None));

--- a/src/map/methods.rs
+++ b/src/map/methods.rs
@@ -209,12 +209,12 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
 
     /// Attempt to insert a pair into the map. (no panic)
     ///
+    /// - If the key exists, whether the map is full or not, we update the
+    ///   value (exclude key), and return `Some(Some(old_value))`;
     /// - If the key does not exist and the map is full already, we can do
     ///   nothing, so just return `None`;
     /// - If the key does not exist and the map has empty slot, we insert
     ///   into that slot and return `Some(None)`.
-    /// - If the key exists, whether the map is full or not, we update the
-    ///   value (exclude key), and return `Some(Some(old_value))`;
     ///
     /// # Examples
     /// ```
@@ -247,7 +247,8 @@ impl<K: PartialEq, V, const N: usize> Map<K, V, N> {
 
     /// Insert a single key-value pair into the map, updating the key as well.
     ///
-    /// If the map did not have this key present, [None] is returned.
+    /// If the map did not have this key present, [`None`] is returned, which
+    /// means the insertion successful.
     ///
     /// If the map did have this key present, the key-value pair is updated, and
     /// the old key-value pair is returned. Note that unlike

--- a/src/map/values.rs
+++ b/src/map/values.rs
@@ -13,7 +13,7 @@ impl<K, V, const N: usize> Map<K, V, N> {
     /// # Examples
     /// ```
     /// use micromap::Map;
-    /// let mut m = Map::from([("a", 1), ("b", 2), ("c", 3)]);
+    /// let m = Map::from([("a", 1), ("b", 2), ("c", 3)]);
     /// // print "a", "b", "c" in arbitrary order.
     /// for val in m.values() {
     ///     println!("{val}");

--- a/src/set.rs
+++ b/src/set.rs
@@ -38,24 +38,33 @@ use crate::map::Map;
 /// up to eight key-values pairs:
 ///
 /// ```
-/// let mut m : micromap::Set<u64, 8> = micromap::Set::new();
-/// m.insert(1);
-/// m.insert(2);
-/// assert_eq!(2, m.len());
+/// use micromap::Set;
+/// let mut set : Set<u64, 8> = Set::new();
+/// set.insert(1);
+/// set.insert(2);
+/// assert_eq!(set.len(), 2);
+/// assert_eq!(set.capacity(), 8);
 /// ```
 ///
 /// It is faster because it doesn't use a hash function at all. It simply keeps
-/// all pairs in an array and when it's necessary to find a value, it goes through
-/// all pairs comparing the needle with each pair available. Also it is faster
-/// because it doesn't use heap. When a [`Set`] is being created, it allocates the necessary
-/// space on stack. That's why the maximum size of the set must be provided in
-/// compile time.
+/// all items in an array and when it's necessary to find a value, it goes through
+/// all items comparing the needle with each pair available. Also it is faster
+/// because it doesn't use heap. When a [`Set`] is being created, it allocates the
+/// necessary space on stack. That's why the maximum size of the set must be
+/// provided in compile time.
 ///
 /// It is also faster because it doesn't grow in size. When a [`Set`] is created,
-/// its size is fixed on stack. If an attempt is made to insert too many keys
-/// into it, it simply panics. Moreover, in the "release" mode it doesn't panic,
-/// but its behaviour is undefined. In the "release" mode all boundary checks
-/// are disabled, for the sake of higher performance.
+/// its size is fixed on stack (or as `Box<Set<_>>` on heap if you like). If an
+/// attempt is made to [`insert()`] too many value into it, it simply panics (or
+/// you can use [`checked_insert()`]). Moreover, for method [`insert_unchecked()`]
+/// in the "release" mode, it doesn't panic, instead, **its behaviour is undefined**.
+/// In the "release" mode all boundary checks are disabled, for the sake of higher
+/// performance (But in general, you can just use [`insert()`] or [`checked_insert()`]
+/// in most cases).
+///
+/// [`insert()`]: Set::insert
+/// [`checked_insert()`]: Set::checked_insert
+/// [`insert_unchecked()`]: Set::insert_unchecked
 #[repr(transparent)]
 pub struct Set<T, const N: usize> {
     map: Map<T, (), N>,

--- a/src/set.rs
+++ b/src/set.rs
@@ -3,6 +3,7 @@
 
 //! A small Set implemented as a Linear Map where the value is `()`.
 
+mod bitand;
 mod clone;
 mod ctors;
 mod debug;
@@ -21,7 +22,6 @@ mod serialization;
 mod sub;
 mod symmetric_difference;
 mod union;
-mod bitand;
 // mod bitor; // need nightly Rust to enable `#![feature(generic_const_exprs)]`
 // mod bitxor; // need nightly Rust to enable `#![feature(generic_const_exprs)]`
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -21,6 +21,9 @@ mod serialization;
 mod sub;
 mod symmetric_difference;
 mod union;
+mod bitand;
+// mod bitor; // need nightly Rust to enable `#![feature(generic_const_exprs)]`
+// mod bitxor; // need nightly Rust to enable `#![feature(generic_const_exprs)]`
 
 // re-export
 pub use difference::Difference;

--- a/src/set/bitand.rs
+++ b/src/set/bitand.rs
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023-2025 Yegor Bugayenko
+// SPDX-FileCopyrightText: Copyright (c) 2025 owtotwo
+// SPDX-License-Identifier: MIT
+
+use super::Set;
+
+// If we can use `#![feature(generic_const_exprs)]`, use `Set<T, min(N, M)>` as the
+// const generic parameter to replace the `Set<T, N>`.
+impl<T, const M: usize, const N: usize> core::ops::BitAnd<&Set<T, M>> for &Set<T, N>
+where
+    T: PartialEq + Clone,
+{
+    type Output = Set<T, N>;
+
+    /// Returns the intersection of `self` and `rhs` as a new `Set<T, N>`.
+    ///
+    /// # Examples
+    /// ```
+    /// use micromap::Set;
+    /// let a = Set::from([1, 2, 3]);
+    /// let b = Set::from([2, 3, 4, 5]);
+    /// let set = &a & &b;
+    /// let mut i = 0;
+    /// let expected = [2, 3];
+    /// for x in &set {
+    ///     assert!(expected.contains(x));
+    ///     i += 1;
+    /// }
+    /// assert_eq!(i, expected.len());
+    /// ```
+    fn bitand(self, rhs: &Set<T, M>) -> Set<T, N> {
+        self.intersection(rhs).cloned().collect()
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::Set;
+
+    #[test]
+    fn bitand_with_non_empty_sets() {
+        let a = Set::from([1, 2, 3]);
+        let b = Set::from([2, 3, 4, 5]);
+        let set = &a & &b;
+        let mut i = 0;
+        let expected = [2, 3];
+        for x in &set {
+            assert!(expected.contains(x));
+            i += 1;
+        }
+        assert_eq!(i, expected.len());
+    }
+
+    #[test]
+    fn bitand_with_disjoint_sets() {
+        let a = Set::from([1, 2, 3]);
+        let b = Set::from([4, 5, 6]);
+        let set = &a & &b;
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn bitand_with_empty_set() {
+        let a = Set::from([1, 2, 3]);
+        let b: Set<i32, 0> = Set::new();
+        let set = &a & &b;
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn bitand_with_self() {
+        let a = Set::from([1, 2, 3]);
+        let set = &a & &a;
+        let mut i = 0;
+        let expected = [1, 2, 3];
+        for x in &set {
+            assert!(expected.contains(x));
+            i += 1;
+        }
+        assert_eq!(i, expected.len());
+    }
+
+    #[test]
+    fn bitand_with_subset() {
+        let a = Set::from([1, 2, 3]);
+        let b = Set::from([2, 3]);
+        let set = &a & &b;
+        let mut i = 0;
+        let expected = [2, 3];
+        for x in &set {
+            assert!(expected.contains(x));
+            i += 1;
+        }
+        assert_eq!(i, expected.len());
+    }
+}

--- a/src/set/ctors.rs
+++ b/src/set/ctors.rs
@@ -13,13 +13,20 @@ impl<T, const N: usize> Default for Set<T, N> {
 }
 
 impl<T, const N: usize> Set<T, N> {
-    /// Make it.
+    /// Creates an empty `Set`.
     ///
-    /// The size of the set is defined by the generic argument. For example,
-    /// this is how you make a set of four key-values pairs:
+    /// The set is initially created with a capacity of N, so even if you
+    /// don't insert any values, it will occupy a fixed stack memory space.
+    ///
+    /// # Examples
+    /// ```
+    /// use micromap::Set;
+    /// let set: Set<i32, 8> = Set::new();
+    /// assert_eq!(set.len(), 0);
+    /// assert_eq!(set.capacity(), 8);
+    /// ```
     #[inline]
     #[must_use]
-    #[allow(clippy::uninit_assumed_init)]
     pub const fn new() -> Self {
         Self {
             map: Map::<T, (), N>::new(),

--- a/src/set/difference.rs
+++ b/src/set/difference.rs
@@ -48,8 +48,11 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
 /// use micromap::Set;
 /// let a = Set::from([1, 2, 3]);
 /// let b = Set::from([4, 2, 3, 4]);
-/// let mut difference = a.difference(&b);
+/// let diff = a.difference(&b);
+/// assert_eq!(diff.count(), 1);
 /// ```
+#[must_use = "this returns the difference as an iterator, without modifying \
+              either input set"]
 pub struct Difference<'a, 'b, T, const M: usize> {
     // iterator of the first set
     iter: Iter<'a, T>,
@@ -113,12 +116,13 @@ impl<T: core::fmt::Debug + PartialEq, const M: usize> core::fmt::Debug
     }
 }
 
-mod difference_ref {
+pub mod difference_ref {
     use super::{Iter, Set};
 
     impl<'a, T: PartialEq + ?Sized, const N: usize> Set<&'a T, N> {
+        /// A [`difference()`][Set::difference] method with more elaborate lifetime and
+        /// just for `Set<&T>`.
         #[inline]
-        #[must_use]
         pub fn difference_ref<'b, 'set1, 'set2, const M: usize>(
             &'set1 self,
             other: &'set2 Set<&'b T, M>,
@@ -134,6 +138,23 @@ mod difference_ref {
         }
     }
 
+    /// A lazy iterator producing reference elements in the difference of
+    /// Linear `Set`s.
+    ///
+    /// This `struct` is created by the [`difference_ref`] method on [`Set`].
+    ///
+    /// [`difference_ref`]: Set::difference_ref
+    ///
+    /// # Examples
+    /// ```
+    /// use micromap::Set;
+    /// let a = Set::from(["foo", "bar", "baz"]);
+    /// let b = Set::from(["fox", "foo", "baz", "bro"]);
+    /// let diff = (&a).difference_ref(&b);
+    /// assert_eq!(diff.count(), 1);
+    /// ```
+    #[must_use = "this returns the difference as an iterator, without modifying \
+                  either input set"]
     pub struct DifferenceRef<'a, 'b, 'set, T: ?Sized, const M: usize> {
         // iterator of the first set
         iter: Iter<'a, &'a T>,

--- a/src/set/difference.rs
+++ b/src/set/difference.rs
@@ -50,7 +50,6 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
 /// let b = Set::from([4, 2, 3, 4]);
 /// let mut difference = a.difference(&b);
 /// ```
-#[must_use = "this returns the difference as an iterator, without modifying either input set"]
 pub struct Difference<'a, 'b, T, const M: usize> {
     // iterator of the first set
     iter: Iter<'a, T>,
@@ -119,6 +118,7 @@ mod difference_ref {
 
     impl<'a, T: PartialEq + ?Sized, const N: usize> Set<&'a T, N> {
         #[inline]
+        #[must_use]
         pub fn difference_ref<'b, 'set1, 'set2, const M: usize>(
             &'set1 self,
             other: &'set2 Set<&'b T, M>,
@@ -134,7 +134,6 @@ mod difference_ref {
         }
     }
 
-    #[must_use = "this returns the difference as an iterator, without modifying either input set"]
     pub struct DifferenceRef<'a, 'b, 'set, T: ?Sized, const M: usize> {
         // iterator of the first set
         iter: Iter<'a, &'a T>,

--- a/src/set/drain.rs
+++ b/src/set/drain.rs
@@ -16,6 +16,18 @@ impl<T, const N: usize> Set<T, N> {
     /// If the returned iterator is dropped before being fully consumed, it drops the
     /// remaining elements. The returned iterator keeps a mutable borrow on the set
     /// to optimize its implementation.
+    ///
+    /// # Examples
+    /// ```
+    /// use micromap::Set;
+    /// let mut set = Set::from([1, 2, 3]);
+    /// assert!(!set.is_empty());
+    /// // print 1, 2, 3 in an arbitrary order
+    /// for i in set.drain() {
+    ///     println!("{i}");
+    /// }
+    /// assert!(set.is_empty());
+    /// ```
     pub fn drain(&mut self) -> Drain<'_, T> {
         Drain {
             iter: self.map.drain(),

--- a/src/set/drain.rs
+++ b/src/set/drain.rs
@@ -4,6 +4,18 @@
 use super::Set;
 use core::iter::FusedIterator;
 
+/// A draining iterator over the items of a `Set`.
+///
+/// This `struct` is created by the [`drain`][Set::drain] method on [`Set`].
+/// See its documentation for more.
+///
+/// # Examples
+/// ```
+/// use micromap::Set;
+/// let mut set = Set::from([1, 2, 3]);
+/// let drain = set.drain();
+/// assert_eq!(drain.len(), 3);
+/// ```
 #[repr(transparent)]
 pub struct Drain<'a, T> {
     iter: crate::map::drain::Drain<'a, T, ()>,

--- a/src/set/intersection.rs
+++ b/src/set/intersection.rs
@@ -54,7 +54,6 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
 /// let b = Set::from([4, 2, 3, 4]);
 /// let mut intersection = a.intersection(&b);
 /// ```
-#[must_use = "this returns the intersection as an iterator, without modifying either input set"]
 pub struct Intersection<'a, T, const M: usize> {
     // iterator of the first set
     iter: Iter<'a, T>,

--- a/src/set/intersection.rs
+++ b/src/set/intersection.rs
@@ -52,8 +52,11 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
 /// use micromap::Set;
 /// let a = Set::from([1, 2, 3]);
 /// let b = Set::from([4, 2, 3, 4]);
-/// let mut intersection = a.intersection(&b);
+/// let intersection = a.intersection(&b);
+/// assert_eq!(intersection.count(), 2);
 /// ```
+#[must_use = "this returns the intersection as an iterator, without modifying \
+              either input set"]
 pub struct Intersection<'a, T, const M: usize> {
     // iterator of the first set
     iter: Iter<'a, T>,

--- a/src/set/iterators.rs
+++ b/src/set/iterators.rs
@@ -17,9 +17,24 @@ pub struct IntoIter<T, const N: usize> {
 }
 
 impl<T, const N: usize> Set<T, N> {
-    /// Make an iterator over all pairs.
+    /// An iterator visiting all elements in arbitrary order. The iterator
+    /// element type is `&'a T`.
+    ///
+    /// # Examples
+    /// ```
+    /// use micromap::Set;
+    /// let mut set: Set<_, 3> = Set::new();
+    /// set.insert("a");
+    /// set.insert("b");
+    /// // Will print in an arbitrary order.
+    /// for x in set.iter() {
+    ///     println!("{x}");
+    /// }
+    /// ```
+    ///
+    /// # Performance
+    /// In the current implementation, iterating over set takes O(len) time.
     #[inline]
-    #[must_use]
     pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             iter: self.map.keys(),

--- a/src/set/methods.rs
+++ b/src/set/methods.rs
@@ -68,10 +68,7 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
     ///   modified: original value is not replaced, and the value passed as argument is dropped.
     ///
     /// # Panics
-    /// It may panic if there are too many pairs in the set already. Pay attention,
-    /// it panics only in the "debug" mode. In the "release" mode, you are going to get
-    /// undefined behavior. This is done for the sake of performance, in order to
-    /// avoid a repetitive check for the boundary condition on every `insert()`.
+    /// It may panic if there are too many items in the set already to contain another new item.
     #[inline]
     pub fn insert(&mut self, k: T) -> bool {
         self.map.insert(k, ()).is_none()

--- a/src/set/methods.rs
+++ b/src/set/methods.rs
@@ -159,9 +159,9 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
     ///
     /// - If the value exists, whether the set is full or not, we update the
     ///   value (exclude key), and return `Some(Some(old_value))`;
-    /// - If the key does not exist and the map is full already, we can do
+    /// - If the key does not exist and the set is full already, we can do
     ///   nothing, so just return `None`;
-    /// - If the key does not exist and the map has empty slot, we insert
+    /// - If the key does not exist and the set has empty slot, we insert
     ///   into that slot and return `Some(None)`.
     ///
     ///
@@ -201,7 +201,7 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
     /// assert_eq!(set.checked_insert(Foo(2, 'b')), None);
     /// assert_eq!(set.checked_insert(Foo(3, 'c')), None);
     /// assert_eq!(set.len(), set.capacity());
-    /// // map is full now.
+    /// // set is full now.
     /// assert_eq!(set.checked_insert(Foo(2, 'B')).unwrap().1, 'B');
     /// // This insertion will cause capacity overflow, so no insertion is performed
     /// // and `None` is returned.
@@ -250,7 +250,7 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
     /// avoid a repetitive check for the boundary condition on every `insert()`.
     ///
     /// # Safety
-    /// Calling this method to add a new key-value pair when the [`Map`] is already
+    /// Calling this method to add a new key-value pair when the [`Set`] is already
     /// full is **undefined behavior instead of panic**. So you need to make sure that
     /// the set is not full before calling.
     #[inline]

--- a/src/set/methods.rs
+++ b/src/set/methods.rs
@@ -233,12 +233,14 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
     /// let mut set: Set<_, 3> = Set::new();
     /// assert_eq!(set.len(), 0);
     /// assert_eq!(set.capacity(), 3);
-    /// assert_eq!(set.insert_unchecked(0), true);
-    /// assert_eq!(set.insert_unchecked(1), true);
-    /// assert_eq!(set.insert_unchecked(2), true);
-    /// assert_eq!(set.insert_unchecked(2), false);
-    /// assert_eq!(set.len(), set.capacity()); // 3
-    /// // assert_eq!(set.insert_unchecked(3), true); // CAN NOT DO THIS!
+    /// unsafe {
+    ///     assert_eq!(set.insert_unchecked(0), true);
+    ///     assert_eq!(set.insert_unchecked(1), true);
+    ///     assert_eq!(set.insert_unchecked(2), true);
+    ///     assert_eq!(set.insert_unchecked(2), false);
+    ///     assert_eq!(set.len(), set.capacity()); // 3
+    ///     // assert_eq!(set.insert_unchecked(3), true); // CAN NOT DO THIS!
+    /// }
     /// ```
     ///
     /// # Panics

--- a/src/set/symmetric_difference.rs
+++ b/src/set/symmetric_difference.rs
@@ -43,8 +43,11 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
 /// use micromap::Set;
 /// let a = Set::from([1, 2, 3]);
 /// let b = Set::from([4, 2, 3, 4]);
-/// let mut sym_diff = a.symmetric_difference(&b);
+/// let sym_diff = a.symmetric_difference(&b);
+/// assert_eq!(sym_diff.count(), 2);
 /// ```
+#[must_use = "this returns the difference as an iterator, without modifying \
+              either input set"]
 pub struct SymmetricDifference<'a, T, const N: usize, const M: usize> {
     iter: core::iter::Chain<Difference<'a, 'a, T, M>, Difference<'a, 'a, T, N>>,
 }

--- a/src/set/symmetric_difference.rs
+++ b/src/set/symmetric_difference.rs
@@ -45,7 +45,6 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
 /// let b = Set::from([4, 2, 3, 4]);
 /// let mut sym_diff = a.symmetric_difference(&b);
 /// ```
-#[must_use = "this returns the difference as an iterator, without modifying either input set"]
 pub struct SymmetricDifference<'a, T, const N: usize, const M: usize> {
     iter: core::iter::Chain<Difference<'a, 'a, T, M>, Difference<'a, 'a, T, N>>,
 }

--- a/src/set/union.rs
+++ b/src/set/union.rs
@@ -41,8 +41,11 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
 /// use micromap::Set;
 /// let a = Set::from([1, 2, 3]);
 /// let b = Set::from([4, 2, 3, 4]);
-/// let mut union = a.union(&b);
+/// let union = a.union(&b);
+/// assert_eq!(union.count(), 4);
 /// ```
+#[must_use = "this returns the union as an iterator, without modifying either \
+              input set"]
 pub struct Union<'a, T, const M: usize> {
     iter: core::iter::Chain<Iter<'a, T>, Difference<'a, 'a, T, M>>,
 }

--- a/src/set/union.rs
+++ b/src/set/union.rs
@@ -43,7 +43,6 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
 /// let b = Set::from([4, 2, 3, 4]);
 /// let mut union = a.union(&b);
 /// ```
-#[must_use = "this returns the union as an iterator, without modifying either input set"]
 pub struct Union<'a, T, const M: usize> {
     iter: core::iter::Chain<Iter<'a, T>, Difference<'a, 'a, T, M>>,
 }


### PR DESCRIPTION
First of all, please don't be surprised by the large amount of changes.

There are so many code changes because I should have divided them into several or even more small PRs, but this would make the merging process take a lot of time for you (even though most of them have no intersection).

In fact, these changes themselves are not complicated. You can clearly see them by **looking at the changes and the corresponding commit messages one by one** in chronological order.

Additional note: There is still [a lot of discussion](https://users.rust-lang.org/search?q=must_use) on the Internet about `#[must_use]`.
Check this: https://rust-lang.github.io/rust-clippy/master/index.html#/must_use_candidate

My opinion is that the Clippy should let the pure functions be set `#[must_use]` by default, and functions with side effects be explicitly marked.
But Rust offical linter (clippy) have apparently not yet considered the relevant issues, so **we won't use it for now** (otherwise it would probably fill up the world).

This PR has largely improved the content of the project documentation and document testing to a "sufficient" level.
(And it takes some time, I can even use it to complete a game of Civilization 6. 😆)