### PR TITLE
Added deterministic random test with comparison between `std::collections::HashMap`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "tiny-keccak",
 ]
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "foldhash"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
@@ -265,7 +265,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -419,6 +431,7 @@ dependencies = [
  "bincode",
  "criterion",
  "flurry",
+ "foldhash",
  "hashbrown",
  "heapless",
  "indexmap",
@@ -426,9 +439,12 @@ dependencies = [
  "linked-hash-map",
  "litemap",
  "nohash-hasher",
+ "rand",
  "rustc-hash",
+ "seq-macro",
  "serde",
  "tinymap",
+ "uuid",
 ]
 
 [[package]]
@@ -538,6 +554,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,6 +670,12 @@ name = "seize"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "689224d06523904ebcc9b482c6a3f4f7fb396096645c4cd10c0d2ff7371a34d3"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -736,6 +779,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom 0.3.2",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,6 +808,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -906,6 +967,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ indexmap = "2.2.6"
 litemap = "0.7.0"
 flurry = "0.5.2"
 criterion = "0.5.1"
+seq-macro = "0.3.6"
+rand = { version = "0.9.0", default-features = false, features = ["small_rng"] }
+uuid = { version = "1.16.0", default-features = false, features = ["v4"] }
+foldhash = { version = "0.1.5", default-features = false }
 
 [features]
 default = []
@@ -45,3 +49,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 [[bench]]
 name = "bench"
 harness = false
+
+[[test]]
+name = "random"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ litemap = "0.7.0"
 flurry = "0.5.2"
 criterion = "0.5.1"
 seq-macro = "0.3.6"
-rand = { version = "0.9.0", default-features = false, features = ["small_rng"] }
+rand = { version = "0.9.1", default-features = false, features = ["small_rng"] }
 uuid = { version = "1.16.0", default-features = false, features = ["v4"] }
 foldhash = { version = "0.1.5", default-features = false }
 

--- a/tests/random.rs
+++ b/tests/random.rs
@@ -17,12 +17,14 @@ use uuid::Uuid;
 const ROUNDS: usize = 12345; // 123456 is ok, but a bit slower. (XOR_EXPECT=0xFD9A2154FC6C60DD)
 const XOR_EXPECT: u64 = 0x150D46E005A17B7C; // for a specific ROUNDS=12345
 
-fn main() {
-    each_capacity();
-}
-
+// cargo test --test random (without --release)
 #[test]
 fn each_capacity() {
+    // Only run in debug mode (opt-level=0). Because this is a deterministic result, it is
+    // calculated at compile time when optimization is enabled.
+    if !cfg!(debug_assertions) {
+        return;
+    }
     let mut xor_hash = 0u64;
     seq!(N in 0..257 {
         let micro_map: Map<Uuid, [u8; 16], N> = Map::new();

--- a/tests/random.rs
+++ b/tests/random.rs
@@ -14,6 +14,8 @@ use std::collections::HashMap;
 use uuid::Builder;
 use uuid::Uuid;
 
+// DON'T change the code unless you know what you are doing.
+
 const ROUNDS: usize = 12345; // 123456 is ok, but a bit slower. (XOR_EXPECT=0xFD9A2154FC6C60DD)
 const XOR_EXPECT: u64 = 0x150D46E005A17B7C; // for a specific ROUNDS=12345
 

--- a/tests/random.rs
+++ b/tests/random.rs
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 owtotwo
 // SPDX-License-Identifier: MIT
 
+#![cfg(debug_assertions)]
+
 use seq_macro::seq;
 use std::hash::Hash;
 use std::vec;
@@ -14,19 +16,19 @@ use std::collections::HashMap;
 use uuid::Builder;
 use uuid::Uuid;
 
+// This is a deterministic random test.
 // DON'T change the code unless you know what you are doing.
 
 const ROUNDS: usize = 12345; // 123456 is ok, but a bit slower. (XOR_EXPECT=0xFD9A2154FC6C60DD)
 const XOR_EXPECT: u64 = 0x150D46E005A17B7C; // for a specific ROUNDS=12345
 
-// cargo test --test random (without --release)
+/// Run this by:
+/// `$ cargo test --test random (without --release)`
+///
+/// Note: only run in debug mode (opt-level=0), cause this is a deterministic result, it will be
+/// calculated at compile time when optimization is enabled and it will stuck.
 #[test]
 fn each_capacity() {
-    // Only run in debug mode (opt-level=0). Because this is a deterministic result, it is
-    // calculated at compile time when optimization is enabled.
-    if !cfg!(debug_assertions) {
-        return;
-    }
     let mut xor_hash = 0u64;
     seq!(N in 0..257 {
         let micro_map: Map<Uuid, [u8; 16], N> = Map::new();

--- a/tests/random.rs
+++ b/tests/random.rs
@@ -8,6 +8,7 @@ use seq_macro::seq;
 use std::hash::Hash;
 use std::vec;
 
+use indexmap::IndexMap;
 use micromap::Map;
 use rand::rngs::SmallRng;
 use rand::Rng;
@@ -36,6 +37,11 @@ fn each_capacity() {
         let hash_map: HashMap<Uuid, [u8; 16]> = HashMap::new();
         let hashmap_results = for_n::<N>(hash_map);
         assert_eq!(micromap_results, hashmap_results);
+        // Or use IndexMap instead of HashMap if you want, the final
+        // result sequence is consistent.
+        // let index_map: IndexMap<Uuid, [u8; 16]> = IndexMap::new();
+        // let indexmap_results = for_n::<N>(index_map);
+        // assert_eq!(indexmap_results, micromap_results);
         for result in micromap_results {
             let hash_val = make_hash(&result, ROUNDS as u64);
             xor_hash ^= hash_val;
@@ -113,6 +119,42 @@ where
 
     fn remove(&mut self, key: &K) -> Option<V> {
         self.remove(key)
+    }
+
+    fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&K, &mut V) -> bool,
+    {
+        self.retain(f)
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn contains_key(&self, key: &K) -> bool {
+        self.contains_key(key)
+    }
+
+    fn clear(&mut self) {
+        self.clear()
+    }
+}
+
+impl<K, V, const N: usize> IsMap<K, V, N> for IndexMap<K, V>
+where
+    K: PartialEq + Eq + Hash,
+{
+    fn get(&self, key: &K) -> Option<&V> {
+        self.get(key)
+    }
+
+    fn insert(&mut self, key: K, value: V) -> Option<V> {
+        self.insert(key, value)
+    }
+
+    fn remove(&mut self, key: &K) -> Option<V> {
+        self.swap_remove(key)
     }
 
     fn retain<F>(&mut self, f: F)

--- a/tests/random.rs
+++ b/tests/random.rs
@@ -1,0 +1,375 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023-2025 Yegor Bugayenko
+// SPDX-FileCopyrightText: Copyright (c) 2025 owtotwo
+// SPDX-License-Identifier: MIT
+
+use seq_macro::seq;
+use std::hash::Hash;
+use std::vec;
+
+use micromap::Map;
+use rand::rngs::SmallRng;
+use rand::Rng;
+use rand::SeedableRng;
+use std::collections::HashMap;
+use uuid::Builder;
+use uuid::Uuid;
+
+const ROUNDS: usize = 12345; // 123456 is ok, but a bit slower.
+
+fn main() {
+    each_capacity();
+}
+
+#[test]
+fn each_capacity() {
+    seq!(N in 0..257 {
+        let micro_map: Map<Uuid, [u8; 16], N> = Map::new();
+        let micromap_results = for_n::<N>(micro_map);
+        // println!("[MicroMap] results for N={}: \n{:?}", N, micromap_results);
+        let hash_map: HashMap<Uuid, [u8; 16]> = HashMap::new();
+        let hashmap_results = for_n::<N>(hash_map);
+        // println!("[HashMap ] results for N={}: \n{:?}", N, hashmap_results);
+        assert_eq!(micromap_results, hashmap_results);
+        // let result_hashes = results.iter().map(|result| make_hash(result, 0)).collect::<Vec<_>>();
+        // hint::black_box(result_hashes);
+        // println!("result_hashes for N={}: {:?}", N, result_hashes);
+    });
+}
+
+trait IsMap<K, V, const N: usize>
+where
+    Self: Default + Sized,
+{
+    fn get(&self, key: &K) -> Option<&V>;
+    fn insert(&mut self, key: K, value: V) -> Option<V>;
+    fn remove(&mut self, key: &K) -> Option<V>;
+    fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&K, &mut V) -> bool;
+    fn len(&self) -> usize;
+    fn contains_key(&self, key: &K) -> bool;
+    fn clear(&mut self);
+}
+
+impl<K, V, const N: usize> IsMap<K, V, N> for Map<K, V, N>
+where
+    K: PartialEq,
+{
+    fn get(&self, key: &K) -> Option<&V> {
+        self.get(key)
+    }
+
+    fn insert(&mut self, key: K, value: V) -> Option<V> {
+        self.insert(key, value)
+    }
+
+    fn remove(&mut self, key: &K) -> Option<V> {
+        self.remove(key)
+    }
+
+    fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&K, &mut V) -> bool,
+    {
+        self.retain(f)
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn contains_key(&self, key: &K) -> bool {
+        self.contains_key(key)
+    }
+
+    fn clear(&mut self) {
+        self.clear()
+    }
+}
+
+impl<K, V, const N: usize> IsMap<K, V, N> for HashMap<K, V>
+where
+    K: PartialEq + Eq + Hash,
+{
+    fn get(&self, key: &K) -> Option<&V> {
+        self.get(key)
+    }
+
+    fn insert(&mut self, key: K, value: V) -> Option<V> {
+        self.insert(key, value)
+    }
+
+    fn remove(&mut self, key: &K) -> Option<V> {
+        self.remove(key)
+    }
+
+    fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&K, &mut V) -> bool,
+    {
+        self.retain(f)
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn contains_key(&self, key: &K) -> bool {
+        self.contains_key(key)
+    }
+
+    fn clear(&mut self) {
+        self.clear()
+    }
+}
+
+enum MapOp<K, V> {
+    Get(K),
+    Insert(K, V),
+    Remove(K),
+    Retain(Box<dyn Fn(&K, &mut V) -> bool>),
+    GetLen,
+    ContainsKey(K),
+    Clear,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+enum OpResult<K, V> {
+    Len(usize),
+    Key(Option<K>),
+    Value(Option<V>),
+    KeyValue(Option<(K, V)>),
+    Boolean(bool),
+    None,
+}
+
+impl MapOp<Uuid, [u8; 16]> {
+    fn apply<'a, 'b, const N: usize>(
+        self,
+        map: &mut impl IsMap<Uuid, [u8; 16], N>,
+    ) -> OpResult<Uuid, [u8; 16]> {
+        match self {
+            MapOp::Get(key) => {
+                let value = map.get(&key);
+                OpResult::Value(value.cloned())
+            }
+            MapOp::Insert(key, value) => {
+                let old_value = map.insert(key, value);
+                OpResult::Value(old_value)
+            }
+            MapOp::Remove(key) => {
+                let taken_value = map.remove(&key);
+                OpResult::Value(taken_value)
+            }
+            MapOp::Retain(f) => {
+                map.retain(f);
+                OpResult::None
+            }
+            MapOp::GetLen => {
+                let len = map.len();
+                OpResult::Len(len)
+            }
+            MapOp::ContainsKey(key) => {
+                let yes = map.contains_key(&key);
+                OpResult::Boolean(yes)
+            }
+            MapOp::Clear => {
+                map.clear();
+                OpResult::None
+            }
+        }
+    }
+}
+
+fn for_n<const N: usize>(mut map: impl IsMap<Uuid, [u8; 16], N>) -> Vec<OpResult<Uuid, [u8; 16]>> {
+    // create a random number generator with a seed based on N
+    let mut rng = SmallRng::seed_from_u64(N as u64);
+    // create a pool with a specific number of unique UUIDs
+    let mut uuids = vec![];
+    let uuids_len = usize::max(64, N);
+    for _ in 0..uuids_len {
+        let random_bytes = rng.random();
+        let uuid = Builder::from_bytes(random_bytes).into_uuid();
+        uuids.push(uuid);
+    }
+    // create the random operation sequence for the map
+    let mut map_ops: Vec<MapOp<Uuid, [u8; 16]>> = Vec::new();
+    // for empty map
+    map_ops.push(MapOp::GetLen);
+    map_ops.push(MapOp::Clear);
+    map_ops.push(MapOp::ContainsKey(uuids[rng.random_range(0..uuids_len)]));
+    map_ops.push(MapOp::Remove(uuids[rng.random_range(0..uuids_len)]));
+    map_ops.push(MapOp::Get(uuids[rng.random_range(0..uuids_len)]));
+    map_ops.push(MapOp::GetLen);
+    map_ops.push(MapOp::Retain(Box::new(|k, _| make_hash(k, 0) % 2 == 0)));
+    // for one element map
+    if N > 0 {
+        map_ops.push(MapOp::Insert(uuids[0], rng.random()));
+        map_ops.push(MapOp::GetLen);
+        map_ops.push(MapOp::Insert(uuids[0], rng.random()));
+        map_ops.push(MapOp::GetLen);
+        map_ops.push(MapOp::Get(uuids[rng.random_range(0..uuids_len)]));
+        map_ops.push(MapOp::Retain(Box::new(|k, _| make_hash(k, 0) % 2 == 0)));
+        map_ops.push(MapOp::ContainsKey(uuids[1]));
+        map_ops.push(MapOp::Remove(uuids[1]));
+        map_ops.push(MapOp::ContainsKey(uuids[1]));
+        map_ops.push(MapOp::GetLen);
+        map_ops.push(MapOp::Remove(uuids[1]));
+        map_ops.push(MapOp::Remove(uuids[0]));
+        map_ops.push(MapOp::GetLen);
+        map_ops.push(MapOp::Remove(uuids[0]));
+        map_ops.push(MapOp::GetLen);
+        map_ops.push(MapOp::Clear);
+    }
+    // for three elements map
+    if N >= 3 {
+        map_ops.push(MapOp::Insert(uuids[0], rng.random()));
+        map_ops.push(MapOp::Insert(uuids[1], rng.random()));
+        map_ops.push(MapOp::Insert(uuids[2], rng.random()));
+        map_ops.push(MapOp::GetLen);
+        map_ops.push(MapOp::ContainsKey(uuids[2]));
+        map_ops.push(MapOp::Get(uuids[3]));
+        map_ops.push(MapOp::Get(uuids[2]));
+        map_ops.push(MapOp::Get(uuids[0]));
+        map_ops.push(MapOp::Get(uuids[1]));
+        map_ops.push(MapOp::Remove(uuids[0]));
+        map_ops.push(MapOp::GetLen);
+        map_ops.push(MapOp::Remove(uuids[2]));
+        map_ops.push(MapOp::GetLen);
+        map_ops.push(MapOp::ContainsKey(uuids[2]));
+        map_ops.push(MapOp::Remove(uuids[0]));
+        map_ops.push(MapOp::Remove(uuids[2]));
+        map_ops.push(MapOp::GetLen);
+        map_ops.push(MapOp::Remove(uuids[1]));
+        map_ops.push(MapOp::GetLen);
+        map_ops.push(MapOp::Retain(Box::new(|k, _| make_hash(k, 0) % 2 == 0)));
+        map_ops.push(MapOp::Clear);
+    }
+    // for half-full map (N >= 4)
+    if N >= 4 {
+        for uuid in uuids.iter().take(N / 2) {
+            map_ops.push(MapOp::Insert(*uuid, uuid.into_bytes()));
+        }
+        map_ops.push(MapOp::GetLen);
+        map_ops.push(MapOp::Remove(uuids[rng.random_range(0..uuids_len)]));
+        map_ops.push(MapOp::Remove(uuids[1]));
+        map_ops.push(MapOp::Retain(Box::new(|k, _| make_hash(k, 0) % 2 == 0)));
+        map_ops.push(MapOp::ContainsKey(uuids[rng.random_range(0..uuids_len)]));
+        map_ops.push(MapOp::GetLen);
+        map_ops.push(MapOp::Clear);
+    }
+    // for almost-full map (N >= 3)
+    if N >= 3 {
+        for uuid in uuids.iter().take(N - 1) {
+            map_ops.push(MapOp::Insert(*uuid, uuid.into_bytes()));
+        }
+        map_ops.push(MapOp::GetLen);
+        map_ops.push(MapOp::Retain(Box::new(|k, _| make_hash(k, 0) % 2 == 0)));
+        map_ops.push(MapOp::GetLen);
+        for uuid in uuids.iter() {
+            map_ops.push(MapOp::Remove(*uuid));
+        }
+        map_ops.push(MapOp::GetLen);
+        map_ops.push(MapOp::Clear);
+    }
+    // for full map (N >= 3)
+    if N >= 3 {
+        for _ in 0..ROUNDS {
+            let i = rng.random_range(0..N);
+            let uuid = uuids[i].clone();
+            if rng.random_ratio(85, 100) {
+                map_ops.push(MapOp::Insert(uuid, uuid.into_bytes()));
+            } else {
+                map_ops.push(MapOp::Remove(uuid));
+            }
+            if rng.random_ratio(10, 100) {
+                map_ops.push(MapOp::GetLen);
+            }
+        }
+        map_ops.push(MapOp::Clear);
+    }
+    // apply the operation sequence to the map
+    let mut results = Vec::new();
+    for op in map_ops {
+        results.push(op.apply::<N>(&mut map));
+    }
+    return results;
+}
+
+fn make_hash<K: core::hash::Hash>(k: &K, seed: u64) -> u64 {
+    use core::hash::BuildHasher;
+    let state = foldhash::fast::FixedState::with_seed(seed);
+    state.hash_one(k)
+}
+
+// #[test]
+// fn random_test() {
+//     let mut rng = SmallRng::seed_from_u64(1);
+
+//     let mut uuids = vec![];
+//     for _ in 0..64 {
+//         let random_bytes = rng.random();
+//         let uuid = Builder::from_bytes(random_bytes).into_uuid();
+//         uuids.push(uuid);
+//     }
+
+//     let key_index_list: Vec<usize> = (0..10000).map(|_| rng.random_range(0..64)).collect();
+//     let value_list: Vec<[u8; 16]> = (0..10000).map(|_| rng.random()).collect();
+//     let remove_key_index_list: Vec<usize> = (0..10000)
+//         .step_by(20)
+//         .map(|i| key_index_list[i + rng.random_range(0..20)])
+//         .collect();
+//     let remove_or_not_list: Vec<bool> = (0..10000).map(|_| rng.random_range(0..100) < 10).collect();
+//     // let mut do_remove_after_insert_i: Vec<usize> = (0..remove_key_index_list.len()).map(|_| rng.random_range(0..10000)).collect();
+//     // do_remove_after_insert_i.sort();
+//     // println!("remove_key_index_list is {:?}", remove_key_index_list);
+
+//     // get average of key_index_list
+//     let mut sum = 0;
+//     for i in 0..key_index_list.len() {
+//         sum += key_index_list[i];
+//     }
+//     let avg = sum as f64 / key_index_list.len() as f64;
+//     println!("key_index_list avg is {:?}", avg);
+
+//     let mut sum = 0;
+
+//     for _ in 0..1234 {
+//         let mut m: Map<Uuid, [u8; 16], 64> = Map::new();
+
+//         // let mut before_full = vec![];
+//         // let mut not_full = true;
+//         let mut rm_it = remove_key_index_list.iter();
+//         for i in 0..10000 {
+//             let index = key_index_list[i];
+//             let key = uuids[index];
+//             let value = value_list[i];
+
+//             m.insert(black_box(key), black_box(value));
+
+//             if remove_or_not_list[i] {
+//                 let Some(rm_i) = rm_it.next() else {
+//                     break;
+//                 };
+//                 let key = uuids[*rm_i];
+//                 m.remove(black_box(&key));
+//             }
+
+//             // if not_full {
+//             //     before_full.push(m.len());
+//             //     if m.len() == m.capacity() {
+//             //         not_full = false;
+//             //         println!(
+//             //             "before_full(len={}) is {:?}",
+//             //             before_full.len(),
+//             //             before_full
+//             //         );
+//             //     }
+//             // }
+//         }
+
+//         sum += m.len();
+//     }
+//     println!("sum is {}", sum);
+// }


### PR DESCRIPTION
Generates a deterministic random `Op` sequence using a random number generator with the specific seeds.

For any correctly implemented `Map`, the final result sequence is consistent, that is, you can use other Maps to replace the `std::collections::HashMap`. (e.g. [`indexmap::IndexMap`](https://github.com/indexmap-rs/indexmap))

This test ensures the correctness of the most basic methods for a Map structure.