### PR TITLE
test: increase code coverage to over 96.58% (from 75.57%).

### DIFF
--- a/src/map/ctors.rs
+++ b/src/map/ctors.rs
@@ -90,8 +90,16 @@ mod tests {
     }
 
     #[test]
+    fn makes_map_by_with_capacity() {
+        #[allow(deprecated)]
+        let m: Map<u8, u8, 8> = Map::with_capacity(8);
+        assert_eq!(0, m.len());
+    }
+
+    #[test]
     fn drops_correctly() {
-        let _m: Map<Vec<u8>, u8, 8> = Map::new();
+        let m: Map<Vec<u8>, u8, 8> = Map::new();
+        drop(m);
     }
 
     #[test]

--- a/src/map/entry.rs
+++ b/src/map/entry.rs
@@ -499,5 +499,7 @@ mod tests {
             entry.insert(b'E');
             assert_eq!(entry.remove_entry(), ('e', b'E'));
         }
+        let occupied_entry = m.entry('e').insert_entry(b'e');
+        assert_eq!(occupied_entry.get(), &b'e');
     }
 }

--- a/src/map/iterators.rs
+++ b/src/map/iterators.rs
@@ -508,4 +508,34 @@ mod tests {
         let _i = IterMut::<String, u32>::default();
         let _i = IntoIter::<String, u32, 3>::default();
     }
+
+    #[test]
+    fn iter_count() {
+        let mut m: Map<char, u32, 4> = Map::new();
+        m.insert('a', 97);
+        m.insert('b', 98);
+        m.insert('c', 99);
+        let it = m.iter();
+        assert_eq!(it.count(), 3); // Count all elements
+    }
+
+    #[test]
+    fn iter_mut_count() {
+        let mut m: Map<char, u32, 4> = Map::new();
+        m.insert('a', 97);
+        m.insert('b', 98);
+        m.insert('c', 99);
+        let it_mut = m.iter_mut();
+        assert_eq!(it_mut.count(), 3); // Count all elements
+    }
+
+    #[test]
+    fn into_iter_count() {
+        let mut m: Map<char, u32, 4> = Map::new();
+        m.insert('a', 97);
+        m.insert('b', 98);
+        m.insert('c', 99);
+        let it_owned = m.into_iter();
+        assert_eq!(it_owned.count(), 3); // Count all elements
+    }
 }

--- a/src/map/keys.rs
+++ b/src/map/keys.rs
@@ -199,4 +199,48 @@ mod tests {
             ["bar".to_string(), "foo".to_string()]
         );
     }
+
+    #[test]
+    fn keys_clone() {
+        let mut m: Map<String, i32, 10> = Map::new();
+        m.insert("foo".to_string(), 0);
+        m.insert("bar".to_string(), 0);
+        let keys = m.keys();
+        let cloned_keys = keys.clone();
+        assert_eq!(keys.collect::<Vec<_>>(), cloned_keys.collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn keys_debug() {
+        let mut m: Map<String, i32, 10> = Map::new();
+        m.insert("foo".to_string(), 0);
+        m.insert("bar".to_string(), 0);
+        let keys = m.keys();
+        let debug_output = format!("{:?}", keys);
+        assert!(debug_output.contains("foo"));
+        assert!(debug_output.contains("bar"));
+    }
+
+    #[test]
+    fn keys_default() {
+        let keys: Keys<'_, String, i32> = Keys::default();
+        assert_eq!(keys.len(), 0);
+    }
+
+    #[test]
+    fn into_keys_debug() {
+        let mut m: Map<String, i32, 10> = Map::new();
+        m.insert("foo".to_string(), 0);
+        m.insert("bar".to_string(), 0);
+        let into_keys = m.into_keys();
+        let debug_output = format!("{:?}", into_keys);
+        assert!(debug_output.contains("foo"));
+        assert!(debug_output.contains("bar"));
+    }
+
+    #[test]
+    fn into_keys_default() {
+        let into_keys: IntoKeys<String, i32, 10> = IntoKeys::default();
+        assert_eq!(into_keys.len(), 0);
+    }
 }

--- a/src/map/serialization.rs
+++ b/src/map/serialization.rs
@@ -84,4 +84,30 @@ mod tests {
         assert!(after.is_empty());
         assert_eq!(bytes.len(), read_len);
     }
+
+    #[test]
+    fn serialize_non_empty_map() {
+        let config = bincode::config::legacy();
+        let mut map: Map<u8, u8, 8> = Map::new();
+        map.insert(10, 20);
+        map.insert(30, 40);
+        let mut bytes: [u8; 1024] = [0; 1024];
+        let len = encode_into_slice(&map, &mut bytes, config).unwrap();
+        let bytes = &bytes[..len];
+        let (deserialized_map, read_len): (Map<u8, u8, 8>, usize) =
+            decode_from_slice(&bytes, config).unwrap();
+        assert_eq!(map.len(), deserialized_map.len());
+        assert_eq!(bytes.len(), read_len);
+        for (key, value) in map {
+            assert_eq!(deserialized_map.get(&key), Some(&value));
+        }
+    }
+
+    #[test]
+    fn deserialize_invalid_data() {
+        let config = bincode::config::legacy();
+        let invalid_bytes: [u8; 4] = [0xFF, 0xFF, 0xFF, 0xFF];
+        let result: Result<(Map<u8, u8, 8>, usize), _> = decode_from_slice(&invalid_bytes, config);
+        assert!(result.is_err());
+    }
 }

--- a/src/map/values.rs
+++ b/src/map/values.rs
@@ -311,4 +311,71 @@ mod tests {
         drop(values);
         assert_eq!(1, Rc::strong_count(&v));
     }
+
+    #[test]
+    fn values_clone() {
+        let mut m: Map<i32, String, 10> = Map::new();
+        m.insert(1, "foo".to_string());
+        m.insert(2, "bar".to_string());
+        let values = m.values();
+        let cloned_values = values.clone();
+        assert_eq!(
+            values.collect::<Vec<_>>(),
+            cloned_values.collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn values_default() {
+        let values: Values<'_, String, i32> = Values::default();
+        assert_eq!(values.len(), 0);
+        assert_eq!(values.size_hint(), (0, Some(0)));
+    }
+
+    #[test]
+    fn values_mut_default() {
+        let values_mut: ValuesMut<'_, String, i32> = ValuesMut::default();
+        assert_eq!(values_mut.len(), 0);
+        assert_eq!(values_mut.size_hint(), (0, Some(0)));
+    }
+
+    #[test]
+    fn into_values_default() {
+        let into_values: IntoValues<String, i32, 10> = IntoValues::default();
+        assert_eq!(into_values.len(), 0);
+        assert_eq!(into_values.size_hint(), (0, Some(0)));
+    }
+
+    #[test]
+    fn values_debug() {
+        let mut m: Map<String, i32, 10> = Map::new();
+        m.insert("one".to_string(), 42);
+        m.insert("two".to_string(), 16);
+        let values = m.values();
+        let debug_str = format!("{:?}", values);
+        assert!(debug_str.contains("42"));
+        assert!(debug_str.contains("16"));
+    }
+
+    #[test]
+    fn values_mut_debug() {
+        let mut m: Map<String, i32, 10> = Map::new();
+        m.insert("one".to_string(), 42);
+        m.insert("two".to_string(), 16);
+        let values_mut = m.values_mut();
+        let debug_str = format!("{:?}", values_mut);
+        assert!(debug_str.contains("42"));
+        assert!(debug_str.contains("16"));
+    }
+
+    #[test]
+    fn into_values_debug() {
+        let mut m: Map<String, i32, 10> = Map::new();
+        m.insert("one".to_string(), 42);
+        m.insert("two".to_string(), 16);
+        let into_values = m.into_values();
+        let debug_str = format!("{:?}", into_values);
+        assert!(debug_str.contains("42"));
+        assert!(debug_str.contains("16"));
+    }
 }

--- a/src/set/extend.rs
+++ b/src/set/extend.rs
@@ -44,4 +44,25 @@ mod tests {
         set.extend([2, 3, 5, 6]);
         assert_eq!(set, Set::from([1, 2, 3, 4, 5, 6]));
     }
+
+    #[test]
+    fn extend_set_with_str_references() {
+        let mut set = Set::<&str, 6>::new();
+        set.extend(["a", "b", "c"].iter());
+        assert_eq!(set, Set::from(["a", "b", "c"]));
+    }
+
+    #[test]
+    fn extend_set_with_str_references_overlap() {
+        let mut set = Set::<&str, 6>::from_iter(["a", "b"]);
+        set.extend(["b", "c", "d"].iter());
+        assert_eq!(set, Set::from(["a", "b", "c", "d"]));
+    }
+
+    #[test]
+    fn extend_set_with_str_references_empty() {
+        let mut set = Set::<&str, 6>::from_iter(["a", "b", "c"]);
+        <Set<&str, 6> as Extend<&str>>::extend(&mut set, []); // Fully Qualified Syntax
+        assert_eq!(set, Set::from(["a", "b", "c"]));
+    }
 }

--- a/src/set/from.rs
+++ b/src/set/from.rs
@@ -20,3 +20,29 @@ impl<T: PartialEq, const N: usize> From<[T; N]> for Set<T, N> {
         Self::from_iter(arr)
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::Set;
+
+    #[test]
+    fn test_from_iter() {
+        let vec = vec![1, 2, 3, 4];
+        let set: Set<_, 4> = vec.into_iter().collect();
+        assert!(set.contains(&1));
+        assert!(set.contains(&2));
+        assert!(set.contains(&3));
+        assert!(set.contains(&4));
+        assert!(!set.contains(&5));
+    }
+
+    #[test]
+    fn test_from_array() {
+        let arr = [1, 2, 3, 4];
+        let set: Set<_, 4> = Set::from(arr);
+        assert!(set.contains(&1));
+        assert!(set.contains(&2));
+        assert!(set.contains(&3));
+        assert!(set.contains(&4));
+        assert!(!set.contains(&5));
+    }
+}

--- a/src/set/intersection.rs
+++ b/src/set/intersection.rs
@@ -177,4 +177,24 @@ mod tests {
         assert_eq!(set_d.intersection(&set_b).size_hint(), (0, Some(2)));
         assert_eq!(set_d.intersection(&set_c).size_hint(), (0, Some(0)));
     }
+
+    #[test]
+    fn intersection_clone_fmt_fold() {
+        use core::fmt::Write;
+        let set_a = Set::from([1, 2, 3, 4]);
+        let set_b = Set::from([3, 4, 5, 6]);
+        // Test `clone`
+        let intersection = set_a.intersection(&set_b);
+        let cloned = intersection.clone();
+        let result: Set<_, 2> = cloned.copied().collect();
+        assert_eq!(result, Set::from([3, 4]));
+        // Test `fmt`
+        let mut debug_output = String::new();
+        write!(&mut debug_output, "{:?}", intersection).unwrap();
+        assert!(debug_output.contains("3"));
+        assert!(debug_output.contains("4"));
+        // Test `fold`
+        let sum = intersection.fold(0, |acc, &x| acc + x);
+        assert_eq!(sum, 7); // 3 + 4 = 7
+    }
 }

--- a/src/set/methods.rs
+++ b/src/set/methods.rs
@@ -400,3 +400,145 @@ impl<T: PartialEq, const N: usize> Set<T, N> {
         existing_pair.map(|(k, ())| k)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Set;
+
+    #[test]
+    fn test_capacity() {
+        let set: Set<i32, 10> = Set::new();
+        assert_eq!(set.capacity(), 10);
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let mut set: Set<i32, 5> = Set::new();
+        assert!(set.is_empty());
+        set.insert(1);
+        assert!(!set.is_empty());
+    }
+
+    #[test]
+    fn test_len() {
+        let mut set: Set<i32, 5> = Set::new();
+        assert_eq!(set.len(), 0);
+        set.insert(1);
+        assert_eq!(set.len(), 1);
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut set: Set<i32, 5> = Set::new();
+        set.insert(1);
+        set.clear();
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn test_retain() {
+        let mut set = Set::from([1, 2, 3, 4, 5]);
+        set.retain(|&x| x % 2 == 0);
+        assert_eq!(set, Set::from([2, 4]));
+    }
+
+    #[test]
+    fn test_contains() {
+        let set = Set::from([1, 2, 3]);
+        assert!(set.contains(&1));
+        assert!(!set.contains(&4));
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut set: Set<i32, 5> = Set::new();
+        set.insert(2);
+        assert!(set.remove(&2));
+        assert!(!set.remove(&2));
+    }
+
+    #[test]
+    fn test_insert() {
+        let mut set: Set<i32, 3> = Set::new();
+        assert!(set.insert(2));
+        assert!(!set.insert(2));
+        assert_eq!(set.len(), 1);
+    }
+
+    #[test]
+    fn test_checked_insert() {
+        let mut set: Set<i32, 2> = Set::new();
+        assert_eq!(set.checked_insert(1), None);
+        assert_eq!(set.checked_insert(2), None);
+        assert_eq!(set.checked_insert(3), None);
+        assert_eq!(set.len(), 2);
+    }
+
+    #[test]
+    fn test_insert_unchecked() {
+        let mut set: Set<i32, 3> = Set::new();
+        unsafe {
+            assert!(set.insert_unchecked(1));
+            assert!(set.insert_unchecked(2));
+            assert!(!set.insert_unchecked(2));
+        }
+    }
+
+    #[test]
+    fn test_get() {
+        let set = Set::from([1, 2, 3]);
+        assert_eq!(set.get(&2), Some(&2));
+        assert_eq!(set.get(&4), None);
+    }
+
+    #[test]
+    fn test_take() {
+        let mut set = Set::from([1, 2, 3]);
+        assert_eq!(set.take(&2), Some(2));
+        assert_eq!(set.take(&2), None);
+    }
+
+    #[test]
+    fn test_is_disjoint() {
+        let a = Set::from([1, 2, 3]);
+        let mut b: Set<u32, 5> = Set::new();
+        assert!(a.is_disjoint(&b));
+        assert!(b.is_disjoint(&a));
+        b.insert(4);
+        assert!(a.is_disjoint(&b));
+        assert!(b.is_disjoint(&a));
+        b.insert(1);
+        assert!(!a.is_disjoint(&b));
+        assert!(!b.is_disjoint(&a));
+    }
+
+    #[test]
+    fn test_is_subset() {
+        let sup = Set::from([1, 2, 3]);
+        let mut set: Set<u32, 5> = Set::new();
+        assert!(set.is_subset(&sup));
+        set.insert(2);
+        assert!(set.is_subset(&sup));
+        set.insert(4);
+        assert!(!set.is_subset(&sup));
+    }
+
+    #[test]
+    fn test_is_superset() {
+        let sub = Set::from([1, 2]);
+        let mut set: Set<u32, 5> = Set::new();
+        assert!(!set.is_superset(&sub));
+        set.insert(1);
+        set.insert(2);
+        assert!(set.is_superset(&sub));
+    }
+
+    #[test]
+    fn test_replace() {
+        let mut set: Set<Vec<i32>, 5> = Set::new();
+        set.insert(Vec::new());
+        assert_eq!(set.get(&[][..]).unwrap().capacity(), 0);
+        set.replace(Vec::with_capacity(10));
+        assert_eq!(set.get(&[][..]).unwrap().capacity(), 10);
+    }
+}

--- a/src/set/symmetric_difference.rs
+++ b/src/set/symmetric_difference.rs
@@ -164,4 +164,37 @@ mod tests {
         assert_eq!(set_d.symmetric_difference(&set_b).size_hint(), (4, Some(8)));
         assert_eq!(set_d.symmetric_difference(&set_c).size_hint(), (2, Some(2)));
     }
+
+    #[test]
+    fn symmetric_difference_clone() {
+        let set_a = Set::from([1, 2, 3]);
+        let set_b = Set::from([3, 4, 5]);
+        let sym_diff = set_a.symmetric_difference(&set_b);
+        let cloned = sym_diff.clone();
+        let collected_original: Set<_, 6> = sym_diff.copied().collect();
+        let collected_cloned: Set<_, 6> = cloned.copied().collect();
+        assert_eq!(collected_original, collected_cloned);
+    }
+
+    #[test]
+    fn symmetric_difference_fold() {
+        let set_a = Set::from([1, 2, 3]);
+        let set_b = Set::from([3, 4, 5]);
+        let sym_diff = set_a.symmetric_difference(&set_b);
+        let sum = sym_diff.fold(0, |acc, &x| acc + x);
+        assert_eq!(sum, 1 + 2 + 4 + 5);
+    }
+
+    #[test]
+    fn symmetric_difference_fmt_debug() {
+        let set_a = Set::from([1, 2, 3]);
+        let set_b = Set::from([3, 4, 5]);
+        let sym_diff = set_a.symmetric_difference(&set_b);
+        let debug_output = format!("{:?}", sym_diff);
+        assert!(debug_output.contains("1"));
+        assert!(debug_output.contains("2"));
+        assert!(debug_output.contains("4"));
+        assert!(debug_output.contains("5"));
+        assert!(!debug_output.contains("3"));
+    }
 }

--- a/src/set/union.rs
+++ b/src/set/union.rs
@@ -160,4 +160,51 @@ mod tests {
         assert_eq!(set_d.union(&set_b).size_hint(), (6, Some(8)));
         assert_eq!(set_d.union(&set_c).size_hint(), (2, Some(2)));
     }
+
+    #[test]
+    fn union_default_and_clone() {
+        let set_a = Set::from([1, 2, 3]);
+        let set_b = Set::from([4, 5, 6]);
+        let union = set_a.union(&set_b);
+        let cloned_union = union.clone();
+        assert_eq!(union.count(), cloned_union.count());
+    }
+
+    #[test]
+    fn union_debug_fmt() {
+        let set_a = Set::from([1, 2, 3]);
+        let set_b = Set::from([4, 5, 6]);
+        let union = set_a.union(&set_b);
+        let debug_output = format!("{:?}", union);
+        assert!(debug_output.contains("1"));
+        assert!(debug_output.contains("6"));
+    }
+
+    #[test]
+    fn union_count_and_fold() {
+        let set_a = Set::from([1, 2, 3]);
+        let set_b = Set::from([3, 4, 5]);
+        let union = set_a.union(&set_b);
+        assert_eq!(union.clone().count(), 5);
+        let sum: i32 = union.fold(0, |acc, &x| acc + x);
+        assert_eq!(sum, 15); // 1 + 2 + 3 + 4 + 5
+    }
+
+    #[test]
+    fn union_combined_test() {
+        let set_a = Set::from([1, 2, 3]);
+        let set_b = Set::from([3, 4, 5]);
+        let union = set_a.union(&set_b);
+        // Test clone
+        let cloned_union = union.clone();
+        assert_eq!(union.clone().count(), cloned_union.count());
+        // Test debug fmt
+        let debug_output = format!("{:?}", union);
+        assert!(debug_output.contains("1"));
+        assert!(debug_output.contains("5"));
+        // Test count and fold
+        assert_eq!(union.clone().count(), 5);
+        let sum: i32 = union.fold(0, |acc, &x| acc + x);
+        assert_eq!(sum, 15); // 1 + 2 + 3 + 4 + 5
+    }
 }


### PR DESCRIPTION
The uncovered lines are basically the `cargo-tarpaulin` recognition omissions.
Because this is a bug in [`tarpaulin`](https://github.com/xd009642/tarpaulin), we cannot intervene, so that reaching the 100% code coverage is impossible.

In summary, we have basically completed the coverage of most of the code.